### PR TITLE
v1.2.0 drop deprecated categoryMask, register mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,32 @@ npm install pixijs-actions
 yarn add pixijs-actions
 ```
 
-2. Import `pixijs-actions` somewhere in your application. The DisplayObject mixin and its types are automatically registered when you import the library.
-
-3. Register the global ticker with your PixiJS app (or other render loop):
+2. Register the DisplayObject mixin:
 
 ```ts
-import { Action } from 'pixijs-actions';
+import * as PIXI from 'pixi.js';
+import { registerDisplayObjectMixin } from 'pixijs-actions';
+
+registerDisplayObjectMixin(PIXI.DisplayObject);
+```
+
+2. Register the `registerDisplayObjectMixin()` mixin and ticker with your PixiJS app (or other render loop):
+
+```ts
+import * as PIXI from 'pixi.js';
+import { Action, registerDisplayObjectMixin } from 'pixijs-actions';
+
+// Register the Actions mixin
+registerDisplayObjectMixin(PIXI.DisplayObject);
 
 const myApp = new PIXI.Application({ ... });
 
-// PixiJS v8:
-myApp.ticker.add(ticker => Action.tick(ticker.deltaTime));
-
-// or PixiJS v6 + v7:
-myApp.ticker.add(dt => Action.tick(dt));
+// Tick actions
+myApp.ticker.add(ticker => Action.tick(ticker.deltaTime)); // PixiJS v8
+myApp.ticker.add(dt => Action.tick(dt)); // PixiJS v6 + v7
 ```
 
-Now you are ready to start using actions!
+Now you can add your first action!
 
 ## Action Initializers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixijs-actions",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pixijs-actions",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixijs-actions",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "author": "Reece Como <reece.como@gmail.com>",
   "authors": [
     "Reece Como <reece.como@gmail.com>",

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -94,15 +94,10 @@ export abstract class _ extends Action {
    * Tick all actions forward.
    *
    * @param deltaTimeMs Delta time in milliseconds.
-   * @param categoryMask (Optional) Bitmask to filter which categories of actions to update.
-   * @param onErrorHandler (Optional) Handler errors from each action's tick.
+   * @param onErrorHandler Handle action errors.
    */
-  public static tick(
-    deltaTimeMs: number,
-    categoryMask: number | undefined = undefined,
-    onErrorHandler?: (error: any) => void
-  ): void {
-    ActionTicker.tickAll(deltaTimeMs, categoryMask, onErrorHandler);
+  public static tick(deltaTimeMs: number, onErrorHandler?: (error: any) => void): void {
+    ActionTicker.tickAll(deltaTimeMs, onErrorHandler);
   }
 
   //

--- a/src/DisplayObject.mixin.ts
+++ b/src/DisplayObject.mixin.ts
@@ -18,9 +18,10 @@ export function registerDisplayObjectMixin(displayObject: any): void {
   prototype.isPaused = false;
 
   // - Methods:
-  prototype.run = function (_action: Action, completion?: () => void): void {
-    const action = completion ? Action.sequence([_action, Action.run(completion)]) : _action;
-    ActionTicker.runAction(undefined, this, action);
+  prototype.run = function (action: Action, completion?: () => void): void {
+    return completion
+      ? ActionTicker.runAction(undefined, this, Action.sequence([action, Action.run(completion)]))
+      : ActionTicker.runAction(undefined, this, action);
   };
 
   prototype.runWithKey = function (action: Action, key: string): void {

--- a/src/__tests__/Action.test.ts
+++ b/src/__tests__/Action.test.ts
@@ -1,5 +1,5 @@
-import { Container, Sprite } from 'pixi.js';
-import { Action, TimingMode } from '../index';
+import { Container, DisplayObject, Sprite } from 'pixi.js';
+import { Action, TimingMode, registerDisplayObjectMixin } from '../index';
 // import { registerDisplayObjectMixin } from '../DisplayObject.mixin';
 
 function simulateTime(seconds: number, steps: number = 100): void {
@@ -12,7 +12,7 @@ function simulateTime(seconds: number, steps: number = 100): void {
 }
 
 /** Load the DisplayObject mixin first. */
-// beforeAll(() => registerDisplayObjectMixin(DisplayObject));
+beforeAll(() => registerDisplayObjectMixin(DisplayObject));
 
 describe('DefaultTimingMode static properties', () => {
   it('should reflect the DefaultTimingModeEaseInOut on the root Action type', () => {
@@ -255,10 +255,8 @@ describe('Action Chaining', () => {
     });
 
     it('should work with repeatForever()', () => {
-      let i = 0;
       const myCustomAction = Action.customAction(5.0, (target, t) => {
         target.position.x = 5.0 * t;
-        i++;
       });
 
       const myNode = new Container();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,6 @@
-import * as PIXI from 'pixi.js';
-
 import { _ as Action } from "./Action";
 import { TimingMode, TimingModeFn } from "./TimingMode";
 import { registerDisplayObjectMixin } from './DisplayObject.mixin';
-
-//
-// ----- [Side-effect] Initialize DisplayObject mixin: -----
-//
-
-registerDisplayObjectMixin(PIXI.DisplayObject);
 
 //
 // ----- PixiJS Actions library: -----

--- a/src/lib/Action.ts
+++ b/src/lib/Action.ts
@@ -20,8 +20,6 @@ export abstract class Action {
     public speed: number = 1,
     /** A setting that controls the speed curve of an animation. */
     public timingMode: TimingModeFn = TimingMode.linear,
-    /** @deprecated A global category bitmask which can be used to group actions. */
-    public categoryMask: number = 0x1,
   ) {
     if (duration < 0) {
       throw new RangeError('Action duration must be 0 or more.');
@@ -31,19 +29,6 @@ export abstract class Action {
   /** Duration of the action after its local speed scalar is applied. */
   public get scaledDuration(): number {
     return this.duration / this.speed;
-  }
-
-  /**
-   * @deprecated To be removed soon. Modify node and action speed directly instead.
-   *
-   * Set a category mask for this action.
-   * Use this to tick different categories of actions separately (e.g. separate different UI).
-   *
-   * This function mutates the underlying action.
-   */
-  public setCategory(categoryMask: number): this {
-    this.categoryMask = categoryMask;
-    return this;
   }
 
   /**

--- a/src/lib/ActionTicker.ts
+++ b/src/lib/ActionTicker.ts
@@ -21,14 +21,9 @@ export class ActionTicker {
    * Tick all actions forward.
    *
    * @param deltaTimeMs Delta time given in milliseconds.
-   * @param categoryMask (Optional) Bitmask to filter which categories of actions to update.
-   * @param onErrorHandler (Optional) Handler errors from each action's tick.
+   * @param onErrorHandler Handle action errors.
    */
-  public static tickAll(
-    deltaTimeMs: number,
-    categoryMask: number | undefined = undefined,
-    onErrorHandler?: (error: any) => void
-  ): void {
+  public static tickAll(deltaTimeMs: number, onErrorHandler?: (error: any) => void): void {
     const deltaTime = deltaTimeMs * 0.001;
 
     for (const [target, tickers] of this._tickers.entries()) {
@@ -39,15 +34,11 @@ export class ActionTicker {
       }
 
       for (const actionTicker of tickers.values()) {
-        if (categoryMask !== undefined && (categoryMask & actionTicker.action.categoryMask) === 0) {
-          continue;
-        }
-
         try {
           actionTicker.tick(deltaTime * speed);
         }
         catch (error) {
-          // Isolate individual action errors.
+          // Report individual action errors.
           if (onErrorHandler === undefined) {
             console.error('Action failed with error: ', error);
           }


### PR DESCRIPTION
### What's changed?
- No longer automatically registering mixin, which means it can be done ad-hoc at the best time for the application.
- Removed deprecated `categoryMask` / `setCategory()` - Use `speed` instead.
- Updated docs