### PR TITLE
v1.2.2: first class PixiJS v8 support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: "lint"
+name: "eslint"
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: "eslint"
+name: "lint"
 
 on:
   push:
@@ -13,16 +13,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [20.x]
-
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
       - run: npm install
       - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,19 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
+        pixi-version: [6.1.0, 7.2.0, 8.1.0]
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: npm install
+
+      - name: Use pixi.js@${{ matrix.node-version }}
+        run: npm install pixi-js@${{ matrix.pixi-version}}
+
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,22 +18,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - label: PixiJS v6
-            package: pixi.js@v6.5.10
+          # https://pixijs.com/versions
 
-          - label: PixiJS v7
-            package: pixi.js@v7.4.2
+          - label: v6
+            package-version: 6.5.10
 
-          - label: PixiJS v8
-            package: pixi.js@v8.1.0
+          - label: v7
+            package-version: 7.4.2
 
-    name: Test @ ${{ matrix.label }}
+          - label: v8
+            package-version: 8.1.0
+
+    name: PixiJS ${{ matrix.label }} (@${{ matrix.package-version }})
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
       - run: npm install
-      - name: Use ${{ matrix.package }}
-        run: npm install ${{ matrix.package }}
+      - name: Install PixiJS v${{ matrix.package-version }}
+        run: npm install pixi.js@v${{ matrix.package-version }}
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,14 +25,14 @@ jobs:
             typescript-version: 4.2.3
 
           - label: v7
-            package-version: 7.4.2
+            pixi-version: 7.4.2
             typescript-version: 5.4.5
 
           - label: v8
-            package-version: 8.1.0
+            pixi-version: 8.1.0
             typescript-version: 5.4.5
 
-    name: PixiJS ${{ matrix.label }} (@${{ matrix.pixi-version }})
+    name: pixi.js ${{ matrix.label }} (@v${{ matrix.pixi-version }})
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "tests"
+name: "test"
 
 on:
   push:
@@ -15,23 +15,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        node-version: [20.x]
-        pixi-version: [6.1.0, 7.2.0, 8.1.0]
+        pixijs-package:
+          - pixi.js@v6.1.0
+          - pixi.js@v7.2.0
+          - pixi.js@v8.1.0
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
-
+          node-version: 20.x
       - run: npm install
-
-      - name: Use pixi.js@${{ matrix.node-version }}
-        run: npm install pixi-js@${{ matrix.pixi-version}}
-
+      - name: Use ${{ matrix.pixijs-package }}
+        run: npm install ${{ matrix.pixijs-package }}
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,21 +21,24 @@ jobs:
           # https://pixijs.com/versions
 
           - label: v6
-            package-version: 6.5.10
+            pixi-version: 6.5.10
+            typescript-version: 4.2.3
 
           - label: v7
             package-version: 7.4.2
+            typescript-version: 5.4.5
 
           - label: v8
             package-version: 8.1.0
+            typescript-version: 5.4.5
 
-    name: PixiJS ${{ matrix.label }} (@${{ matrix.package-version }})
+    name: PixiJS ${{ matrix.label }} (@${{ matrix.pixi-version }})
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
       - run: npm install
-      - name: Install PixiJS v${{ matrix.package-version }}
-        run: npm install pixi.js@v${{ matrix.package-version }}
+      - name: Install PixiJS v${{ matrix.pixi-version }}
+        run: npm install pixi.js@v${{ matrix.pixi-version }} typescript@v${{ matrix.typescript-version }}
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pixijs-package:
-          - pixi.js@v6.1.0
-          - pixi.js@v7.2.0
-          - pixi.js@v8.1.0
+        include:
+          - label: PixiJS v6
+            package: pixi.js@v6.5.10
 
+          - label: PixiJS v7
+            package: pixi.js@v7.4.2
+
+          - label: PixiJS v8
+            package: pixi.js@v8.1.0
+
+    name: Test @ ${{ matrix.label }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
       - run: npm install
-      - name: Use ${{ matrix.pixijs-package }}
-        run: npm install ${{ matrix.pixijs-package }}
+      - name: Use ${{ matrix.package }}
+        run: npm install ${{ matrix.package }}
       - run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,29 @@ jobs:
         include:
           # https://pixijs.com/versions
 
-          - label: v6
-            pixi-version: 6.5.10
-            typescript-version: 4.2.3
+          - label: v6.3
+            pixi-version: '6.3.2'
+            typescript-version: '4.9.5'
 
-          - label: v7
-            pixi-version: 7.4.2
-            typescript-version: 5.4.5
+          - label: v6.x
+            pixi-version: '6.x.x'
+            typescript-version: '4.9.5'
 
-          - label: v8
-            pixi-version: 8.1.0
-            typescript-version: 5.4.5
+          - label: v7.0
+            pixi-version: '7.0.0'
+            typescript-version: '4.9.5'
+
+          - label: v7.x
+            pixi-version: '7.x.x'
+            typescript-version: '5.4.5'
+
+          - label: v8.0
+            pixi-version: '8.0.0'
+            typescript-version: '5.4.5'
+
+          - label: v8.x
+            pixi-version: '8.x.x'
+            typescript-version: '5.4.5'
 
     name: pixi.js ${{ matrix.label }} (@v${{ matrix.pixi-version }})
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: "test"
+name: "tests"
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎬 pixijs-actions &nbsp;[![NPM version](https://img.shields.io/npm/v/pixijs-actions.svg?style=flat-square)](https://www.npmjs.com/package/pixijs-actions) [![test ci/cd status badge](https://github.com/reececomo/pixijs-actions/actions/workflows/test.yml/badge.svg)](https://github.com/reececomo/pixijs-actions/actions/workflows/test.yml) [![lint ci/cd status badge](https://github.com/reececomo/pixijs-actions/actions/workflows/lint.yml/badge.svg)](https://github.com/reececomo/pixijs-actions/actions/workflows/lint.yml)
 
-PixiJS Actions allow developers to easily configure complex, high-performance animations in [PixiJS](https://pixijs.com/).
+PixiJS Actions allows developers to easily configure complex, high-performance animations in [PixiJS](https://pixijs.com/).
 
 - 🚀 35+ [built-in actions](#action-initializers), 30+ [smoothing options](#timing-modes)
 - 🔀 Reuseable, chainable & reversible actions
@@ -63,10 +63,10 @@ yarn add pixijs-actions --dev
 
 ```ts
 import * as PIXI from 'pixi.js';
-import { Action, registerDisplayObjectMixin } from 'pixijs-actions';
+import { Action, registerPixiJSActionsMixin } from 'pixijs-actions';
 
-// Register mixin for container.
-registerDisplayObjectMixin(PIXI.Container);
+// Register mixin for containers.
+registerPixiJSActionsMixin(PIXI.Container);
 
 // Register `Action.tick(...)` with shared ticker
 Ticker.shared.add(ticker => Action.tick(ticker.elapsedMS));
@@ -105,7 +105,7 @@ Most actions implement specific predefined animations that are ready to use. If 
 | `Action.moveBy(dx, dy, duration)` | Move a node by relative values. | Yes |
 | `Action.moveByX(dx, duration)` | Move a node horizontally by a relative value. | Yes |
 | `Action.moveByY(dy, duration)` | Move a node vertically by a relative value. | Yes |
-| `Action.moveTo(position, duration)` | Move a node to a specified position `{ x, y }` (e.g. `PIXI.Point`, `PIXI.DisplayObject`). |  _*No_ |
+| `Action.moveTo(position, duration)` | Move a node to a specified position `{ x, y }` (e.g. `PIXI.Point`, `PIXI.Container`). |  _*No_ |
 | `Action.moveTo(x, y, duration)` | Move a node to a specified position. |  _*No_ |
 | `Action.moveToX(x, duration)` | Move a node to a specified horizontal position. |  _*No_ |
 | `Action.moveToY(y, duration)` | Move a node to a specified vertical position. |  _*No_ |
@@ -123,7 +123,7 @@ Most actions implement specific predefined animations that are ready to use. If 
 | `Action.scaleBy(dx, dy, duration)` | Scale a node in each axis by relative values. | Yes |
 | `Action.scaleByX(dx, duration)` | Scale a node horizontally by a relative value. | Yes |
 | `Action.scaleByY(dy, duration)` | Scale a node vertically by a relative value. | Yes |
-| `Action.scaleTo(size, duration)` | Scale a node to achieve a specified size `{ width, height }` (e.g. `PIXI.ISize`, `PIXI.DisplayObject`). |  _*No_ |
+| `Action.scaleTo(size, duration)` | Scale a node to achieve a specified size `{ width, height }` (e.g. `PIXI.ISize`, `PIXI.Container`). |  _*No_ |
 | `Action.scaleTo(scale, duration)` | Scale a node to a specified value. |  _*No_ |
 | `Action.scaleTo(x, y, duration)` | Scale a node in each axis to specified values. |  _*No_ |
 | `Action.scaleToX(x, duration)` | Scale a node horizontally to a specified value. |  _*No_ |
@@ -139,7 +139,7 @@ Most actions implement specific predefined animations that are ready to use. If 
 |***Removing a Node from the Canvas***|||
 | `Action.removeFromParent()` | Remove a node from its parent. | _†Identical_ |
 |***Running Actions on Children***|||
-| `Action.runOnChildWithName(action, childName)` | Run an action on a named child node. | Yes |
+| `Action.runOnChild(nameOrLabel, action)` | Add an action to a child node. | Yes |
 |***Delaying Actions***|||
 | `Action.waitForDuration(duration)` | Idle for a specified period of time. | _†Identical_ |
 | `Action.waitForDurationWithRange(duration, range)` | Idle for a randomized period of time. | _†Identical_ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "eslint": "^8.57.0",
         "eslint-plugin-disable-autofix": "^4.2.0",
         "jest": "^29.3.1",
-        "pixi.js": "^6.1.0",
+        "pixi.js": "^6.2.0",
         "ts-jest": "^29.0.5",
         "typescript": "^4.2.3"
       },
       "peerDependencies": {
-        "pixi.js": "^6.1.0 || ^7.0.0 || ^8.0.0"
+        "pixi.js": "^6.2.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1227,277 +1227,279 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.1.0.tgz",
-      "integrity": "sha512-SDbu08F0eXTc5jqkJdLoX5G6yrSD68V5X7nU9+AfVL5mYdR+wkAuDXjcOINbGq2vxHPN6fgoBNZIDNPfRHeATw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
+      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/canvas-renderer": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.1.0.tgz",
-      "integrity": "sha512-QIMNyMpswWAIXo1RhTbnem7DEdNnrYCV8RLK9E9nZ3NlzP3587IuMEmNfwZp7PsvMJXehH2opY/hlYxVOmYxew==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
+      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0"
-      }
-    },
-    "node_modules/@pixi/canvas-renderer": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.1.0.tgz",
-      "integrity": "sha512-dukgaw9OQyFjTZZ/R2jvf+cyxVQA7P+wJVtGO4Ev/TlaLs85KKy1xtnRpgYbF/etPhORRgN232H6rys50B0YjQ==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.1.0.tgz",
-      "integrity": "sha512-3Go+GT43avgzyX4+fFYiTEfjR5pHrzafKpVlMvttC9xGRhMV1BZFDi1rKjHYuYk8SgNycuqRa2RulsoVq0bQUw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
+      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/loaders": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.1.0.tgz",
-      "integrity": "sha512-4mIvvyiovu/tT1m32fQO/pYwGxO/ch9ZGOArAcsVKx0gWEk/Whi0fuJVxgCemu8gpSFkcIJreWnOiLUzZCVpdQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
+      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-u6pXk8K05ZLhFNQxg+mtlHA6IjV0+lr/IDrEbx55eDZo+ImJwI4ummkJ/uiXaNn04GG0tVAQt+y5+e3fJjVFEQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
+      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
       "dev": true,
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/runner": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/ticker": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.1.0.tgz",
-      "integrity": "sha512-Jb1V54kpJXiGjKFx1qe5NhZyl1u6Z1t3o6mWawIFbXKiOJs+nkouUqRyPX2877cu1zkufbAalEe5V8WXOkqixg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
+      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
+    "node_modules/@pixi/extensions": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
+      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
+      "dev": true
+    },
     "node_modules/@pixi/extract": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.1.0.tgz",
-      "integrity": "sha512-QqOb9jZ473mt8NDuAnfD/oUuXefspGLOoVTfHD+NVRP0J3P4Mnzq98ljHHpOFII/XgM8Jam6YRuOlTGyT7H+vg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
+      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.1.0.tgz",
-      "integrity": "sha512-giNst0xR8h3Ulkk3u6JEN8L1TmZsE5JEPZ+brvdZ336k6wiRMxkqIZ2wt1w9cQLq3PY3MAiUO+SZkYr4Zr1GJg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
+      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0"
+        "@pixi/core": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.1.0.tgz",
-      "integrity": "sha512-EskO2DjKGyOwSMQIqVkONJgG8rdF7Ja9EtBBuWGL6V+lE7DUQ0I25+D13+12HD3OMUsEnXyZWmlYtGW9BD9P7g==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
+      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/settings": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/settings": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.1.0.tgz",
-      "integrity": "sha512-8OE8EDyV8KEUhcqwQxeNvW6r0YMBrQXS7IZLUlCvIVdM5rI24qBA1n9ec5w8ofe7A6jdMArmV4NwiNiSHCkYvw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
+      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0"
+        "@pixi/core": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.1.0.tgz",
-      "integrity": "sha512-ZmsLEYhLQLxVbhP688ofv0bmfRXObYk2Xa3ORwKgivyJeX3UqizP+OUHa1mJ+4n6Q50BwtCra/Cg+TJ0q2R0wQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
+      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/math": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.1.0.tgz",
-      "integrity": "sha512-htFHMvW7GId9UTw5c8Mdd4FU3RGTg9aSsQ04yQCJekm54pwQsTGzkbElGTVWHznurflOhjAJJRib6dtWW1CY8A==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
+      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0"
+        "@pixi/core": "6.5.10"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.1.0.tgz",
-      "integrity": "sha512-5qdW1UZOcN8pJsyp/L7qNzGvigGwKB0c+RvI9LKWn/DsWC4WfAhatMtKV7dTsYNSRE+MWaFbelBQZT6wYw05Jg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
+      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0"
+        "@pixi/core": "6.5.10"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.1.0.tgz",
-      "integrity": "sha512-NfbVX/TIXYrzUDItrXCg6c9LKM6Td1O+xXFnM9uP6EQQ1cyH5uUHtkSR0xgnPpdcs8IEa/FgyOmABEJ+G17syA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
+      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.1.0.tgz",
-      "integrity": "sha512-0GijG3v7oWET96FaFC59ozNrXa5D/fROpZSh2ywwL0NRvftLcjHOSDMGxDXhrlfpsjPgLVqDQQUHAcpIKigleA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
+      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/ticker": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.1.0.tgz",
-      "integrity": "sha512-0RcJuWKJx+4r2lZoVWMfSdaMjC+gGTouDrnGFNX6NGRRXXE3vKQdyFlwwkaJzUefvsjbNe4cYxC7iws9lqL3oA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
+      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.1.0.tgz",
-      "integrity": "sha512-4INGyMqO7z02kTzHEp/7sl1TOrIhPmKLx3jNUDyQ/J7RPJJE3ZbgEktZcfmG0tofJoW3KbLqL4fd6k/FIi5Hsw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
+      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
       "dev": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.1.0.tgz",
-      "integrity": "sha512-l3zFMs9ENGB8y5PIRMCf2/7nHXu40yfeBZq4bPYIJJeHztkzaNKDbEFtDOx/Y1+QrG8VX4LiDWQ+sE7Tk+qIRA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
+      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.1.0.tgz",
-      "integrity": "sha512-/l/ohKrxDRkho85TcGPZrturJPQRUSGLoctIkWCqhNePMk9ATLVQ2ihg7GR1glaYqvxMOQXj5qqIfEC/T7eMlw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
+      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/mesh": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.1.0.tgz",
-      "integrity": "sha512-nwmXcfw7cFyhZwNDFHZLyE7dhJvLEZbm0BJ5cpiDb2HC1g4U5+BfGkjxQulUh2JfdOaqTp7EeU8K5okMVvcdnQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
+      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/canvas-renderer": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.1.0.tgz",
-      "integrity": "sha512-F78olhSbF9ukDigA27hqcPFYrqw0Yj6Z+2NLYVxyWD8vys8Cfev8wtztDk50WYVnCRk8BRYiTiEAtBGYIPSbYA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
+      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.1.0"
+        "@pixi/display": "6.5.10"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.1.0.tgz",
-      "integrity": "sha512-c/mrnEv7ZuKnjjaME+8jyOiP/Mtk2cq/UXDEM+lwOX98zVdxiaBFf13BhnMPnVq7Vq1+HeDDRZ2/VIlrLkU9Ag==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
+      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0"
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10"
       }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.1.0.tgz",
-      "integrity": "sha512-Nu/UqG6n66b51UPdfQjuVfuGnM+D3caUqQCq2rLGVJIJmfrd38J0AooOaTtqePuadQWII2g3pFZ+dXv0oN1Blg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
+      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.1.0.tgz",
-      "integrity": "sha512-gLz7eyfz5PAKxL7y9qI47O91WQyzuPFvuWm9sTxyncsgY7nchJxi6vUuxjLtFDd9vzl+/PXFDHyRGFyDe8tSkg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
+      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -1505,137 +1507,140 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.1.0.tgz",
-      "integrity": "sha512-IdQ0gefbDt4anT59MxZznaY3EZQwvGE9K2Jo3+6t+3ZOvRlsgOLHdMFbNy9N0/MzKp9TAvuvzEj5WW2NoHx5Yw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
+      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/graphics": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/text": "6.1.0",
-        "@pixi/ticker": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.1.0.tgz",
-      "integrity": "sha512-Pf6WmyBZSQg9mf3wpB3UvnZNX9GeRDoC4gMcQEYxw0rZDe0Z0JwzrkV0EGGyGHCZSssdx4+K1+vUxUIyFWdymw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
+      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.1.0.tgz",
-      "integrity": "sha512-dVVOGqnCwZIHNtuAyzhw9QXZPtaxq8daDXYyRfmxfKS5SWX86HMl65KJW7rmA9TIua53i/igSSQVWgAhzRkUeg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
+      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
       "dev": true,
-      "dependencies": {
-        "ismobilejs": "^1.1.0"
+      "peerDependencies": {
+        "@pixi/constants": "6.5.10"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.1.0.tgz",
-      "integrity": "sha512-BnaRNiXgiqNNTN2a9WaeMPZtLP+v/D8W/fymNkjg2wWrs4FwnpT0lPGAL0YHFoBO328LI8qTCy6BCBZg74V4aQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
+      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.1.0.tgz",
-      "integrity": "sha512-yL6Fe+xyXb9m/NkofUcigE3+NYUA3VrKajacf/ONXND897A7JLCihqXS9cHJHJGTNL3X+wsba1iZc9Rax5H0Sg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
+      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/ticker": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/ticker": "6.5.10"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.1.0.tgz",
-      "integrity": "sha512-7a0NubCDrLG5pK7rrLAQJoju0EydL71kljm1TgqhcnoYV7n70Dbpoz+N4OuPyObOyEz9VvcnPMy5srp9FNllfw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.1.0.tgz",
-      "integrity": "sha512-7kh7OuYujRGOAw1Pe6EtwH2Yzov80Qss2MtDlHNplJ+loImd/SCthFhsmpRrOb/lSBtxVn3h+pUzV0bc7bxQXg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
+      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/loaders": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.1.0.tgz",
-      "integrity": "sha512-Yul5LqVYr/XW21uNAoMrkjn7p63RfD19c0S6EWCV18QOJaOjz6ZwzPMg6wpm6b+2i/Ob6F8ZFZdSwAM0hznRYg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
+      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/core": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.1.0.tgz",
-      "integrity": "sha512-xcpRzXueq/XPqVJyd0FeJhdnmXcap8clZMrzLjND8blIWS9sJDJKXrpTmNco/JdOrU+vuOkWRau2OSJJKd882A==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
+      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/loaders": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/mesh": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/text": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.1.0.tgz",
-      "integrity": "sha512-tCh1dhmriLKLMcxTJ9usm1UZEK2+M5nEwvyec9kouF4EMi/PiGup65+pwTHK4SvjXD+9vbtTDam39fWYXCpRxg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
+      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/settings": "6.1.0"
+        "@pixi/extensions": "6.5.10",
+        "@pixi/settings": "6.5.10"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-N7LaVjo2NiP0/4DMX6Hj6SsSoFFEA1Pc3U/I/kQJHj9OyLrNSpcl9PZEiPusnuhpMr+zlQKa+MMU+RyTj+06Hw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
+      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
       "dev": true,
       "dependencies": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.1.0",
-        "@pixi/settings": "6.1.0"
+        "@pixi/constants": "6.5.10",
+        "@pixi/settings": "6.5.10"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1766,6 +1771,12 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -3513,12 +3524,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "dev": true
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4619,46 +4624,47 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.1.0.tgz",
-      "integrity": "sha512-uBcM3wivcLq7CPwLGkcyGscsvRST4TcXSlgXaH46P6mxNnJoDgVJtEYwYP+5H9g7b96ZBo5We6lddO+mmz7cXw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
+      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.1.0",
-        "@pixi/app": "6.1.0",
-        "@pixi/compressed-textures": "6.1.0",
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/extract": "6.1.0",
-        "@pixi/filter-alpha": "6.1.0",
-        "@pixi/filter-blur": "6.1.0",
-        "@pixi/filter-color-matrix": "6.1.0",
-        "@pixi/filter-displacement": "6.1.0",
-        "@pixi/filter-fxaa": "6.1.0",
-        "@pixi/filter-noise": "6.1.0",
-        "@pixi/graphics": "6.1.0",
-        "@pixi/interaction": "6.1.0",
-        "@pixi/loaders": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/mesh": "6.1.0",
-        "@pixi/mesh-extras": "6.1.0",
-        "@pixi/mixin-cache-as-bitmap": "6.1.0",
-        "@pixi/mixin-get-child-by-name": "6.1.0",
-        "@pixi/mixin-get-global-position": "6.1.0",
-        "@pixi/particle-container": "6.1.0",
-        "@pixi/polyfill": "6.1.0",
-        "@pixi/prepare": "6.1.0",
-        "@pixi/runner": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/sprite-animated": "6.1.0",
-        "@pixi/sprite-tiling": "6.1.0",
-        "@pixi/spritesheet": "6.1.0",
-        "@pixi/text": "6.1.0",
-        "@pixi/text-bitmap": "6.1.0",
-        "@pixi/ticker": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/accessibility": "6.5.10",
+        "@pixi/app": "6.5.10",
+        "@pixi/compressed-textures": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/extract": "6.5.10",
+        "@pixi/filter-alpha": "6.5.10",
+        "@pixi/filter-blur": "6.5.10",
+        "@pixi/filter-color-matrix": "6.5.10",
+        "@pixi/filter-displacement": "6.5.10",
+        "@pixi/filter-fxaa": "6.5.10",
+        "@pixi/filter-noise": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/interaction": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/mixin-cache-as-bitmap": "6.5.10",
+        "@pixi/mixin-get-child-by-name": "6.5.10",
+        "@pixi/mixin-get-global-position": "6.5.10",
+        "@pixi/particle-container": "6.5.10",
+        "@pixi/polyfill": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/sprite-animated": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/spritesheet": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/text-bitmap": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
       },
       "funding": {
         "type": "opencollective",
@@ -6496,176 +6502,176 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.1.0.tgz",
-      "integrity": "sha512-SDbu08F0eXTc5jqkJdLoX5G6yrSD68V5X7nU9+AfVL5mYdR+wkAuDXjcOINbGq2vxHPN6fgoBNZIDNPfRHeATw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
+      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/app": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.1.0.tgz",
-      "integrity": "sha512-QIMNyMpswWAIXo1RhTbnem7DEdNnrYCV8RLK9E9nZ3NlzP3587IuMEmNfwZp7PsvMJXehH2opY/hlYxVOmYxew==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
+      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
       "dev": true,
-      "requires": {}
-    },
-    "@pixi/canvas-renderer": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.1.0.tgz",
-      "integrity": "sha512-dukgaw9OQyFjTZZ/R2jvf+cyxVQA7P+wJVtGO4Ev/TlaLs85KKy1xtnRpgYbF/etPhORRgN232H6rys50B0YjQ==",
-      "dev": true,
-      "peer": true,
       "requires": {}
     },
     "@pixi/compressed-textures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.1.0.tgz",
-      "integrity": "sha512-3Go+GT43avgzyX4+fFYiTEfjR5pHrzafKpVlMvttC9xGRhMV1BZFDi1rKjHYuYk8SgNycuqRa2RulsoVq0bQUw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
+      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.1.0.tgz",
-      "integrity": "sha512-4mIvvyiovu/tT1m32fQO/pYwGxO/ch9ZGOArAcsVKx0gWEk/Whi0fuJVxgCemu8gpSFkcIJreWnOiLUzZCVpdQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
+      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-u6pXk8K05ZLhFNQxg+mtlHA6IjV0+lr/IDrEbx55eDZo+ImJwI4ummkJ/uiXaNn04GG0tVAQt+y5+e3fJjVFEQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
+      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "@types/offscreencanvas": "^2019.6.4"
+      }
     },
     "@pixi/display": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.1.0.tgz",
-      "integrity": "sha512-Jb1V54kpJXiGjKFx1qe5NhZyl1u6Z1t3o6mWawIFbXKiOJs+nkouUqRyPX2877cu1zkufbAalEe5V8WXOkqixg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
+      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
       "dev": true,
       "requires": {}
     },
+    "@pixi/extensions": {
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
+      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
+      "dev": true
+    },
     "@pixi/extract": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.1.0.tgz",
-      "integrity": "sha512-QqOb9jZ473mt8NDuAnfD/oUuXefspGLOoVTfHD+NVRP0J3P4Mnzq98ljHHpOFII/XgM8Jam6YRuOlTGyT7H+vg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
+      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.1.0.tgz",
-      "integrity": "sha512-giNst0xR8h3Ulkk3u6JEN8L1TmZsE5JEPZ+brvdZ336k6wiRMxkqIZ2wt1w9cQLq3PY3MAiUO+SZkYr4Zr1GJg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
+      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.1.0.tgz",
-      "integrity": "sha512-EskO2DjKGyOwSMQIqVkONJgG8rdF7Ja9EtBBuWGL6V+lE7DUQ0I25+D13+12HD3OMUsEnXyZWmlYtGW9BD9P7g==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
+      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.1.0.tgz",
-      "integrity": "sha512-8OE8EDyV8KEUhcqwQxeNvW6r0YMBrQXS7IZLUlCvIVdM5rI24qBA1n9ec5w8ofe7A6jdMArmV4NwiNiSHCkYvw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
+      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.1.0.tgz",
-      "integrity": "sha512-ZmsLEYhLQLxVbhP688ofv0bmfRXObYk2Xa3ORwKgivyJeX3UqizP+OUHa1mJ+4n6Q50BwtCra/Cg+TJ0q2R0wQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
+      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.1.0.tgz",
-      "integrity": "sha512-htFHMvW7GId9UTw5c8Mdd4FU3RGTg9aSsQ04yQCJekm54pwQsTGzkbElGTVWHznurflOhjAJJRib6dtWW1CY8A==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
+      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.1.0.tgz",
-      "integrity": "sha512-5qdW1UZOcN8pJsyp/L7qNzGvigGwKB0c+RvI9LKWn/DsWC4WfAhatMtKV7dTsYNSRE+MWaFbelBQZT6wYw05Jg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
+      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.1.0.tgz",
-      "integrity": "sha512-NfbVX/TIXYrzUDItrXCg6c9LKM6Td1O+xXFnM9uP6EQQ1cyH5uUHtkSR0xgnPpdcs8IEa/FgyOmABEJ+G17syA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
+      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.1.0.tgz",
-      "integrity": "sha512-0GijG3v7oWET96FaFC59ozNrXa5D/fROpZSh2ywwL0NRvftLcjHOSDMGxDXhrlfpsjPgLVqDQQUHAcpIKigleA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
+      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.1.0.tgz",
-      "integrity": "sha512-0RcJuWKJx+4r2lZoVWMfSdaMjC+gGTouDrnGFNX6NGRRXXE3vKQdyFlwwkaJzUefvsjbNe4cYxC7iws9lqL3oA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
+      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/math": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.1.0.tgz",
-      "integrity": "sha512-4INGyMqO7z02kTzHEp/7sl1TOrIhPmKLx3jNUDyQ/J7RPJJE3ZbgEktZcfmG0tofJoW3KbLqL4fd6k/FIi5Hsw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
+      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.1.0.tgz",
-      "integrity": "sha512-l3zFMs9ENGB8y5PIRMCf2/7nHXu40yfeBZq4bPYIJJeHztkzaNKDbEFtDOx/Y1+QrG8VX4LiDWQ+sE7Tk+qIRA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
+      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.1.0.tgz",
-      "integrity": "sha512-/l/ohKrxDRkho85TcGPZrturJPQRUSGLoctIkWCqhNePMk9ATLVQ2ihg7GR1glaYqvxMOQXj5qqIfEC/T7eMlw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
+      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.1.0.tgz",
-      "integrity": "sha512-nwmXcfw7cFyhZwNDFHZLyE7dhJvLEZbm0BJ5cpiDb2HC1g4U5+BfGkjxQulUh2JfdOaqTp7EeU8K5okMVvcdnQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
+      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.1.0.tgz",
-      "integrity": "sha512-F78olhSbF9ukDigA27hqcPFYrqw0Yj6Z+2NLYVxyWD8vys8Cfev8wtztDk50WYVnCRk8BRYiTiEAtBGYIPSbYA==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
+      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.1.0.tgz",
-      "integrity": "sha512-c/mrnEv7ZuKnjjaME+8jyOiP/Mtk2cq/UXDEM+lwOX98zVdxiaBFf13BhnMPnVq7Vq1+HeDDRZ2/VIlrLkU9Ag==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
+      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/particle-container": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.1.0.tgz",
-      "integrity": "sha512-Nu/UqG6n66b51UPdfQjuVfuGnM+D3caUqQCq2rLGVJIJmfrd38J0AooOaTtqePuadQWII2g3pFZ+dXv0oN1Blg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
+      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
       "dev": true,
       "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.1.0.tgz",
-      "integrity": "sha512-gLz7eyfz5PAKxL7y9qI47O91WQyzuPFvuWm9sTxyncsgY7nchJxi6vUuxjLtFDd9vzl+/PXFDHyRGFyDe8tSkg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
+      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -6673,84 +6679,82 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.1.0.tgz",
-      "integrity": "sha512-IdQ0gefbDt4anT59MxZznaY3EZQwvGE9K2Jo3+6t+3ZOvRlsgOLHdMFbNy9N0/MzKp9TAvuvzEj5WW2NoHx5Yw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
+      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.1.0.tgz",
-      "integrity": "sha512-Pf6WmyBZSQg9mf3wpB3UvnZNX9GeRDoC4gMcQEYxw0rZDe0Z0JwzrkV0EGGyGHCZSssdx4+K1+vUxUIyFWdymw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
+      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.1.0.tgz",
-      "integrity": "sha512-dVVOGqnCwZIHNtuAyzhw9QXZPtaxq8daDXYyRfmxfKS5SWX86HMl65KJW7rmA9TIua53i/igSSQVWgAhzRkUeg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
+      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
       "dev": true,
-      "requires": {
-        "ismobilejs": "^1.1.0"
-      }
+      "requires": {}
     },
     "@pixi/sprite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.1.0.tgz",
-      "integrity": "sha512-BnaRNiXgiqNNTN2a9WaeMPZtLP+v/D8W/fymNkjg2wWrs4FwnpT0lPGAL0YHFoBO328LI8qTCy6BCBZg74V4aQ==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
+      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.1.0.tgz",
-      "integrity": "sha512-yL6Fe+xyXb9m/NkofUcigE3+NYUA3VrKajacf/ONXND897A7JLCihqXS9cHJHJGTNL3X+wsba1iZc9Rax5H0Sg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
+      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.1.0.tgz",
-      "integrity": "sha512-7a0NubCDrLG5pK7rrLAQJoju0EydL71kljm1TgqhcnoYV7n70Dbpoz+N4OuPyObOyEz9VvcnPMy5srp9FNllfw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
+      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
       "dev": true,
       "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.1.0.tgz",
-      "integrity": "sha512-7kh7OuYujRGOAw1Pe6EtwH2Yzov80Qss2MtDlHNplJ+loImd/SCthFhsmpRrOb/lSBtxVn3h+pUzV0bc7bxQXg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
+      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.1.0.tgz",
-      "integrity": "sha512-Yul5LqVYr/XW21uNAoMrkjn7p63RfD19c0S6EWCV18QOJaOjz6ZwzPMg6wpm6b+2i/Ob6F8ZFZdSwAM0hznRYg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
+      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.1.0.tgz",
-      "integrity": "sha512-xcpRzXueq/XPqVJyd0FeJhdnmXcap8clZMrzLjND8blIWS9sJDJKXrpTmNco/JdOrU+vuOkWRau2OSJJKd882A==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
+      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.1.0.tgz",
-      "integrity": "sha512-tCh1dhmriLKLMcxTJ9usm1UZEK2+M5nEwvyec9kouF4EMi/PiGup65+pwTHK4SvjXD+9vbtTDam39fWYXCpRxg==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
+      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-N7LaVjo2NiP0/4DMX6Hj6SsSoFFEA1Pc3U/I/kQJHj9OyLrNSpcl9PZEiPusnuhpMr+zlQKa+MMU+RyTj+06Hw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
+      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
       "dev": true,
       "requires": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -6883,6 +6887,12 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "dev": true
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -8118,12 +8128,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
-      "dev": true
-    },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8963,46 +8967,47 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.1.0.tgz",
-      "integrity": "sha512-uBcM3wivcLq7CPwLGkcyGscsvRST4TcXSlgXaH46P6mxNnJoDgVJtEYwYP+5H9g7b96ZBo5We6lddO+mmz7cXw==",
+      "version": "6.5.10",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
+      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.1.0",
-        "@pixi/app": "6.1.0",
-        "@pixi/compressed-textures": "6.1.0",
-        "@pixi/constants": "6.1.0",
-        "@pixi/core": "6.1.0",
-        "@pixi/display": "6.1.0",
-        "@pixi/extract": "6.1.0",
-        "@pixi/filter-alpha": "6.1.0",
-        "@pixi/filter-blur": "6.1.0",
-        "@pixi/filter-color-matrix": "6.1.0",
-        "@pixi/filter-displacement": "6.1.0",
-        "@pixi/filter-fxaa": "6.1.0",
-        "@pixi/filter-noise": "6.1.0",
-        "@pixi/graphics": "6.1.0",
-        "@pixi/interaction": "6.1.0",
-        "@pixi/loaders": "6.1.0",
-        "@pixi/math": "6.1.0",
-        "@pixi/mesh": "6.1.0",
-        "@pixi/mesh-extras": "6.1.0",
-        "@pixi/mixin-cache-as-bitmap": "6.1.0",
-        "@pixi/mixin-get-child-by-name": "6.1.0",
-        "@pixi/mixin-get-global-position": "6.1.0",
-        "@pixi/particle-container": "6.1.0",
-        "@pixi/polyfill": "6.1.0",
-        "@pixi/prepare": "6.1.0",
-        "@pixi/runner": "6.1.0",
-        "@pixi/settings": "6.1.0",
-        "@pixi/sprite": "6.1.0",
-        "@pixi/sprite-animated": "6.1.0",
-        "@pixi/sprite-tiling": "6.1.0",
-        "@pixi/spritesheet": "6.1.0",
-        "@pixi/text": "6.1.0",
-        "@pixi/text-bitmap": "6.1.0",
-        "@pixi/ticker": "6.1.0",
-        "@pixi/utils": "6.1.0"
+        "@pixi/accessibility": "6.5.10",
+        "@pixi/app": "6.5.10",
+        "@pixi/compressed-textures": "6.5.10",
+        "@pixi/constants": "6.5.10",
+        "@pixi/core": "6.5.10",
+        "@pixi/display": "6.5.10",
+        "@pixi/extensions": "6.5.10",
+        "@pixi/extract": "6.5.10",
+        "@pixi/filter-alpha": "6.5.10",
+        "@pixi/filter-blur": "6.5.10",
+        "@pixi/filter-color-matrix": "6.5.10",
+        "@pixi/filter-displacement": "6.5.10",
+        "@pixi/filter-fxaa": "6.5.10",
+        "@pixi/filter-noise": "6.5.10",
+        "@pixi/graphics": "6.5.10",
+        "@pixi/interaction": "6.5.10",
+        "@pixi/loaders": "6.5.10",
+        "@pixi/math": "6.5.10",
+        "@pixi/mesh": "6.5.10",
+        "@pixi/mesh-extras": "6.5.10",
+        "@pixi/mixin-cache-as-bitmap": "6.5.10",
+        "@pixi/mixin-get-child-by-name": "6.5.10",
+        "@pixi/mixin-get-global-position": "6.5.10",
+        "@pixi/particle-container": "6.5.10",
+        "@pixi/polyfill": "6.5.10",
+        "@pixi/prepare": "6.5.10",
+        "@pixi/runner": "6.5.10",
+        "@pixi/settings": "6.5.10",
+        "@pixi/sprite": "6.5.10",
+        "@pixi/sprite-animated": "6.5.10",
+        "@pixi/sprite-tiling": "6.5.10",
+        "@pixi/spritesheet": "6.5.10",
+        "@pixi/text": "6.5.10",
+        "@pixi/text-bitmap": "6.5.10",
+        "@pixi/ticker": "6.5.10",
+        "@pixi/utils": "6.5.10"
       }
     },
     "pkg-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^4.2.3"
       },
       "peerDependencies": {
-        "pixi.js": ">=6.1.0"
+        "pixi.js": "^6.1.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3312,9 +3312,9 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4812,12 +4812,12 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -4999,17 +4999,17 @@
       "dev": true
     },
     "node_modules/set-function-length": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "dependencies": {
-        "define-data-property": "^1.1.2",
+        "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5037,12 +5037,12 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-      "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
         "object-inspect": "^1.13.1"
@@ -7982,9 +7982,9 @@
       }
     },
     "has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true
     },
     "has-symbols": {
@@ -9112,12 +9112,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dev": true,
       "requires": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       }
     },
     "queue-microtask": {
@@ -9229,17 +9229,17 @@
       }
     },
     "set-function-length": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.1.tgz",
-      "integrity": "sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "requires": {
-        "define-data-property": "^1.1.2",
+        "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "has-property-descriptors": "^1.0.2"
       }
     },
     "shebang-command": {
@@ -9258,12 +9258,12 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.5.tgz",
-      "integrity": "sha512-QcgiIWV4WV7qWExbN5llt6frQB/lBven9pqliLXfGPB+K9ZYXxDozp0wLkHS24kWCm+6YXH/f0HhnObZnZOBnQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.6",
+        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
         "object-inspect": "^1.13.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixijs-actions",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pixijs-actions",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "eslint": "^8.57.0",
         "eslint-plugin-disable-autofix": "^4.2.0",
         "jest": "^29.3.1",
-        "pixi.js": "^6.3.0",
+        "pixi.js": "6.3.x",
         "ts-jest": "^29.0.5",
-        "typescript": "^4.2.3"
+        "typescript": "4.9.5"
       },
       "peerDependencies": {
         "pixi.js": "^6.3.0 || ^7.0.0 || ^8.0.0"
@@ -1227,48 +1227,48 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.0.tgz",
-      "integrity": "sha512-G2IJovkixJ3MdXC456e7Nu9J2nLte01KwJPkWhhuuZkRQI6gBcLHn5flGG+QVx/dZDLySXyHiJ+1MAQ8kI9AbA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.2.tgz",
+      "integrity": "sha512-JLDuSGITGEOmR7s0d1Wxj7a3yIp4hP6w2h6ku6iu3clE/bmVtnvhqMX1D1lhjRW/uWUfpVT4U+8CG+LgSsEZ1g==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.0.tgz",
-      "integrity": "sha512-Ud+D/VkGFCx9Z+i0OXDzXqT3zNrUJ9f3sZuoACz1VVD6nnSq+wBZPnyoOOsgfiMYo/0KYVJh+EdBKZS8aYnnVQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.2.tgz",
+      "integrity": "sha512-V1jnhL92OPiquXtLxUeSZiVDd1mtjRnYpBKA958w29MrIRBx3Y6dgnvsaFZGGWBvSL//WRYV23iZKVL/jRGmmQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.0.tgz",
-      "integrity": "sha512-Y/SHGQZftvSM98/m89a1Pf99c9L5TGEPngueOcmjCABeGI33vOaL2VM4chkHXhG9HLqrHYAty24vXqOj42LbJw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.2.tgz",
+      "integrity": "sha512-E/T9WsWcTstnCaDo3GQZUsvX2bE1tZwJ+rUVQ6ad+9MLI6mpUKJFUy5XXlnZw0uiKU5Hipi1ASPQ8/EQ7kKebA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/loaders": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/loaders": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.0.tgz",
-      "integrity": "sha512-295/bb0+5IugA9plqBnD6xrvApjgGRdaNJ6EryCa7UB2j8wt4YtuzLjNeaCtng9eJONgJXXPhPF85+spdWRMbg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.2.tgz",
+      "integrity": "sha512-sUE8QEJNl4vWUybS0YqpVUBWoOyLkr5bSj1+3mpmbWJTMVmLB2voFXo7XpSNCBlLH1SBN5flcgJlUWOCgNyATg==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.0.tgz",
-      "integrity": "sha512-j7UMizcgDoUB9eDrZIP22xJCPYpjx2/BCl8deE5M9Cim9OR2qPxnNnt3jC1oKf2vVnNMTDrMOLekhMVo89FX2Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-91Fw0CbFpPtMKo5TG1wdaZGgR99lX87l15F7kgge7FM7ZR4EghLiJHU8whQ19f/UNOd8AG7mHD84lUB1VXXfoA==",
       "dev": true,
       "dependencies": {
         "@types/offscreencanvas": "^2019.6.4"
@@ -1278,213 +1278,213 @@
         "url": "https://opencollective.com/pixijs"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/runner": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/ticker": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/runner": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/ticker": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.0.tgz",
-      "integrity": "sha512-Uxc1aLTFzV55d3kOlh/g19RlE2okPXsroi5jfYGCNS0VCdFk0sp6jMNEwk12BwC0KcA5SU7217H4jLy38VCVpA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.2.tgz",
+      "integrity": "sha512-D+WiM0BcyPK91RYxl7TXXVNz/5lOGs8Q6jtCMcWgTHwCXxWPOHFnNZ4KPJZpUQ7me8Tl2u+c9hfB5Oh1+17r/Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/math": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/math": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/extract": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.0.tgz",
-      "integrity": "sha512-p5d3Jx0hoIQZsn1msIOyYCzyRjVkfiDUNkuzpLmNo9zng7C6bwqmIZWEMr5alm7+XwqKHlQdsBuK9PeUJt9fGQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.2.tgz",
+      "integrity": "sha512-9DT3EG5dE/+HlSsbWLZ28/+YwGzHwgOPIMLB8AHxDsWYKzDg+SDK53IUE2UIeEiV8AFHwaDT2K+/qPFUUcS0Bw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.0.tgz",
-      "integrity": "sha512-FyO35T2ym7R/rxaQzz3+dfpMlNn7b4XCFebD7hAgYoLqb+/vaM32ZjjoKBxxFRFqpZxBO6BObCyJQd245h+P4A==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.2.tgz",
+      "integrity": "sha512-EhFnGuzUnQ94tosInBlMEOtiDtTAm4ZbWtoSYrH3GP7WORCQB5asWTFsOZv/QxwEbloRbxsDOATVIwS5ZcgNOg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0"
+        "@pixi/core": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.0.tgz",
-      "integrity": "sha512-TpQxBbFnkcAxMOInMZDprRPXlfhQ0tYOvbnmdDbVTEGOqDXY/7do0bYRfsNshAyeyGE4NVIks1S/RlGkzHLhBg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.2.tgz",
+      "integrity": "sha512-408Z/Rc2LJRg8AaBfzStAph18G0pT3LdLowdTOqPI2s007jgT7wLr9CyWdRe6DdSmPikgnn50R3QG9YeOPWONw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/settings": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/settings": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.0.tgz",
-      "integrity": "sha512-9qKrRiaeINap7BgolI3GZ5RaRgYNx0pK8iyrn7vWcuQAxR/lPM+rfgWQPagjXdU9NbnbnfZj0LNOmgFqtWsZTQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.2.tgz",
+      "integrity": "sha512-PRrQWRRUJ3qDqHhqYNcZ8H3tjXyFbIoUGdTOgB1uCNBHmzJ7Cirhs4lWYBBTvtduboUSGvLMpkv0sgFwodPw4Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0"
+        "@pixi/core": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.0.tgz",
-      "integrity": "sha512-zjOnM3fVh4HOxEHzG/iN00ZmxCuZdxy+xTnjUZkbOgmXtDqRa9HakCBHlg60ZpF/NiIAkJNdrXx6nDhh2hve8Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.2.tgz",
+      "integrity": "sha512-Bda8jY3lVBwlG1GZadYPGXQPO7O+nTt64/KTXQgLtaKB+xj6Me5L7l9IDWtkHEoUTtQK4yCsbkdqKgLKKmNFYg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/math": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/math": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.0.tgz",
-      "integrity": "sha512-dKhKNmQ8zgtvcT2s7nDU/0LETaCzydgosXAeEPO5XtkHA6asffjEAqiie9wpj3DzODOibNuC/wpiiwGmN6xGgw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.2.tgz",
+      "integrity": "sha512-C5Ga5MJlBFoZUa5oOZEsEEByPzpa+JTRVT7+qQ01g4khU1Mnk/p8JvNm6DYUqw9Y821OR80AmHm2O+r5MkLhcQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0"
+        "@pixi/core": "6.3.2"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.0.tgz",
-      "integrity": "sha512-+2qhb/wWkqI86xb2+NMxeoKUiA5Kx6Kvo1jCvSE4PdP5CGCFDLQqnj0NkIZCbl/3L0MiM9vy+JRmY+nVgre8Tw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.2.tgz",
+      "integrity": "sha512-8lZdccDdlKTNktbD+8aeYfceayV6Rzq1P6NLpbvzFZbxH6JoaaNQb2TQgU+Vl/ZcssBB+IJ8MvJZbLuWKC4CmQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0"
+        "@pixi/core": "6.3.2"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.0.tgz",
-      "integrity": "sha512-cnce8ddZSRgVuwK3hdWjEgf9WJljEXlJp+tOIEYvmNYnkvfaRpdeVRpF5yd+A24ZswrVRU9W/W7cXCMw2uq/vQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.2.tgz",
+      "integrity": "sha512-GaykoXJr0pV0e9TB1yOcgvJf9i/fIF/cgT+DnGz82uninWMo31aFJSvhLbZOcEPQRfdHXdFfUkQAAMTICAp7+Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.0.tgz",
-      "integrity": "sha512-ZAgYJPnpQS07r69o6Mgn4SxurY+t05EWblC8bpVssQ/k2yU3xeWAKNV/Hk39AKrM5S+PBU9YyGX//jM+3gt8rQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.2.tgz",
+      "integrity": "sha512-HZyflufAW1B1cQmQBvzv4IxwcHbqQ0zhHiabSVtwPUHW/nCSpw09hL+k4HR/aFyCdRI/99JcvW5QJp1ldA6OBw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/ticker": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/ticker": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.0.tgz",
-      "integrity": "sha512-FXW3DkcAg2w0FABS6ixmzJNQSdabHXWumltelYM76NmBSE8oaLmg6tniBvjrTlSxUs3HlgwdeqgnUHV9GIFxLQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.2.tgz",
+      "integrity": "sha512-kkm1pynWTslQsh+h+Tw17MdeRMQ37Ht72xiZetyWbxadRAnzj+x1I9juEKEFK62mw8K/bGBcNPhu7edgmQwkvw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.0.tgz",
-      "integrity": "sha512-QkF9wl3/kXvthwWhrDAVgWQWl3T9dbyicHsoWfx0s9b3E0rx+PZcpz5ftaAVxGd7EvecIxV9nEUnna9TIjvwJQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.2.tgz",
+      "integrity": "sha512-REXrCKQaT2shJ3p2Rpq1ZYV4iUeAOUFKnLN2KteQWtB5HQpB8b+w5xBGI+TcnY0FUhx92fbKPYTTvCftNZF4Jw==",
       "dev": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.0.tgz",
-      "integrity": "sha512-ljm1lk8ZyxQaZHl53psPptD7eO8yVt7mbEwly+qSyh61Nj950fq5CBgr2cd7TakBSUfiUthYAYP8wmdwop328Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.2.tgz",
+      "integrity": "sha512-zhfagRDGkJx+H4a+Im3wQbCeS0Av1FyHzvPeBXXQ7LP/giwTnvJhItlhGMwgFllNEAIB47An0ffFEe5CmTcyKw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.0.tgz",
-      "integrity": "sha512-rGvpW/UDNPDSALocT2w3jvBpF9TUgyvZMGcxqolIxDbrmRiyUeT1EeYnCQpIqQUnkKW1QKxLpuSjut2yfERe7A==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.2.tgz",
+      "integrity": "sha512-lODKYkoHqynMK8QxE9ttZ1D+3LnHFG13YL4Yf1W9MGgy1N9G0E5DNB8/Z1BApbRxnRPRg8fsoP2bk5Bn9boWyw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/mesh": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/mesh": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.0.tgz",
-      "integrity": "sha512-KIbclUCTv6J2ERIX8LM0PaGezKqfmDbR8X/68irbwsYU3fRtsFb9X4IHttguiItYK8C6syyepEyIRbWB/poc6Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.2.tgz",
+      "integrity": "sha512-Obqnf3Y2JBOtdewkaGb2oa8SDw3+JZCaOB+x0+pBqDivXpwX2eibS4PaYuGVTIa9FdcrGm9SyLOQlL5irEeEqA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.0.tgz",
-      "integrity": "sha512-R1nh985Fffo0HG3gmbbsBgbR0obGdjkVb31V9gUFileydY8u1jVA4sL1uzOfBbHAjDE+HFOO1wC1p6ygalUrkQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.2.tgz",
+      "integrity": "sha512-R6RJzd1aQ5up5N7uO0boOp99gkSZVEbYKofJNRn1pFdzOmuVCgSqERAv9pQnjp5bBD8JvcKN+PYHPn+k+nTprQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.3.0"
+        "@pixi/display": "6.3.2"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.0.tgz",
-      "integrity": "sha512-hDzLubpLSRH6hp+mn8mpONZeMcMc75ndkz6WROXI0gfoUkFdzxHStGBSk4VJRgtSj1zzOgmEqo7LP/y2blgYlw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.2.tgz",
+      "integrity": "sha512-R7F1sH68fiIvB723doEzE0+k8OfhM5N0H+Ncp8iwLwXxfUDSHVj40nIngMtdK4bLSk29TTczOeXOzXkOAEVXhA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0"
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2"
       }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.0.tgz",
-      "integrity": "sha512-yjcMUHIPUL4T27ECBrxgn6j00CpomYLBvdxXWDDqMSnm2W6AA+cy7QM30dCm2mcbStzB4j+cbYvN1+nRIuIE8Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.2.tgz",
+      "integrity": "sha512-iEHtE2AWQ0NZxv57VzfsBbEEp5WXAt91+l2lNvXf1SbzEm/bqjE56Q5bftx9tl3MJlDmOEfPzzKSwIUcZT+T6w==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.0.tgz",
-      "integrity": "sha512-sjOLw0yndRipWOW3ykkCej5+VMZRBmnd32kUXXum9kgceSeL0w+iRPZrfvaFmgypqGnGpqwg24MsZ3vtIffd9g==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.2.tgz",
+      "integrity": "sha512-LTKqL/de7TrBoJNh9netkQofwGBIO3NwwQbqBmP6rHXeaHBx9904Pkuf7GJspIFY09TOo5fnctYnJ1F7LfTljg==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -1492,128 +1492,128 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.0.tgz",
-      "integrity": "sha512-eqQpEIAhctZ85YEQWYMI/LmNyLn8K+lpfH783YQQ1WjFmBrFgJzvm1vs+ztIRl+6EIzVIC28RmcBU15Vkmylew==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.2.tgz",
+      "integrity": "sha512-HFV0jUgr5arNBlgctTRqMCgG42vq48J9QLBCZMCRObJQC5325nEXC1toeEekdzqNcGu5bO8/GKeb6+Km2XK2qA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/graphics": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/text": "6.3.0",
-        "@pixi/ticker": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/graphics": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/text": "6.3.2",
+        "@pixi/ticker": "6.3.2"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.0.tgz",
-      "integrity": "sha512-dG0YK/59dMay1pBD3sXYWtyDQ1gjRY8QCI38b+wQiH9oFMNFtj/f/RxkL1XyaK0r7sC8TjXUiQ+7+lZlmcqIjw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.2.tgz",
+      "integrity": "sha512-Sspv4VTiV51GwoIg+WudHZHpT3ad5ukW20OLOR+eDOSLbgQEMfj4cTVRg27TvM/QZ/5LxeN3FqwWV+kiWpqCnw==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.0.tgz",
-      "integrity": "sha512-UkbZmlexr6NGM6Qz30Et63bpWAmpmkknOOnavrhWPnnbhFIx4kVzU9mvGMHGSGNLJabX9+gFUdjDGSlzF42v4w==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.2.tgz",
+      "integrity": "sha512-i5cLDUWFnRub3LPa3x7IzkH8MjSwPHyHWzIZKG5t8RiCfbhVfhWGEdKO9AYp8yO/xcf7AqtPK4mikXziL48tXA==",
       "dev": true,
       "dependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.0.tgz",
-      "integrity": "sha512-dv0CSkxjWZeUujYQ6NorJ5Cue6SL+RE/H739JK4+cAwEtoWpYqKqiw6aeUu4aqSRsqjhyk9ilhR+K1MbnImJKA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.2.tgz",
+      "integrity": "sha512-T1KJ8l2f8Otn6Se6h4b2pz2nrUSe59Pnmj2WIzgBisM245h7dGATs05MisMaLV6Lg/3gTBTxsLBmKsbDSQqbNw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.0.tgz",
-      "integrity": "sha512-P4VroljvyiAc9acwbUVZTHKwM418x5AFOAEYAx9NkF9izh2HhinjLa+iRK70gPnEBOMPwqn1taVnz/n4/aYHWw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.2.tgz",
+      "integrity": "sha512-fSY64i5BqbOmtFKhgOWf9iML4gId7l5hcniUT/s95+eIZiyYss+jxeekVH22DrAyCOAIdsLEClvGCHGj8iXTFw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/ticker": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/ticker": "6.3.2"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.0.tgz",
-      "integrity": "sha512-4+HodD9QwhiqIptBpT3rXuJDAJ5TSg2IRnHOo/+qSopA70VC1E+RRgyVvxfRfopfptcAHi60XWfzvFLHSV3LsA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.2.tgz",
+      "integrity": "sha512-13zsz0xyxMvobEaSXQghSD44+MpSwpbQJYjPVPb7ItqETqQBaZgHpC5uF6vxFR6Hou8Ca8laxRuwgpn3lA095g==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.0.tgz",
-      "integrity": "sha512-TAIIVA2KFJk7lKB4Ggep99bxpkSjnYlODuLEZ9EoJ6QIEx9A1HesaKwwqzfneeCzX5BOBeJMgZ++rujE29rrpg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.2.tgz",
+      "integrity": "sha512-OCi2BUqcBbh2vvbrnLLBOwxFZMQS+rvjW3udBUNbbqUL+NHy74w8N5Ed8pcxXpdfHbApGG6TVJprCGahtmEfJw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/loaders": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/loaders": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.0.tgz",
-      "integrity": "sha512-hDevLv8HztzdImA6sIvmpBpNoIyDCrMNJAdjTUo/Kw1aoKlDaOGx4K3J7wVTzV1d1WrreIXtOsO3rQUOzf/hmg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.2.tgz",
+      "integrity": "sha512-YiPnUBmgZ0WzF0+XMm07iRg0jOyPbIjGmXJ+1srU5L9c3cCzvtg5QuYL0lPHS0Z6gyxhj/6ncePhBGO87RIKnA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/core": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.0.tgz",
-      "integrity": "sha512-ogoJ+k7MHUEUb8b+yBZOi9jLW/TvIEduf2FJ5S52sovjhjs1/uZw2sdR43tM9BGxP1W9H6GE5yOK5f2sEFZIKg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.2.tgz",
+      "integrity": "sha512-jvMeIxoAGDlSn5rHimISI9F6fTk8D+GXG0YQraRT9oXb1Ugy/bFJph3XOTe46s4oZ5R5QeCLQmo6k7TUIvbSkA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/loaders": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/mesh": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/text": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/loaders": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/mesh": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/text": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.0.tgz",
-      "integrity": "sha512-cEqyQgM5entsi+h85fUnESBzNc/yMRG/mqsfAr7/KraP7bmCcn3MYVuTycRMkRbuNPjC1NIpqkqiOaxzgAUGPw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.2.tgz",
+      "integrity": "sha512-Au9IO85zCOOCz50aJALFxJ2C8gbgxvD0dSNm7A5FauanJbxDcctIyrW6I51nNyHyeLIUFEkuD2jE/DmcXsXnpw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/settings": "6.3.0"
+        "@pixi/settings": "6.3.2"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.0.tgz",
-      "integrity": "sha512-QI5wb/fDdH8DAzIMlrYS0MhG382FPMLh4s3yRtOaftiOb84LL7Syz//SC+CJAyVB0UV/Lpr+T6PiCa4eBjRDgA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.2.tgz",
+      "integrity": "sha512-VpB403kfqwXK9w7Qb6ex0aW0g6pWI/t43F2Z8CA/lAfYcN3O0XoxDucvmkLTQWsMtYn+Yf7YhAcLV5SemKwP0A==",
       "dev": true,
       "dependencies": {
         "@types/earcut": "^2.1.0",
@@ -1622,8 +1622,8 @@
         "url": "^0.11.0"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.3.0",
-        "@pixi/settings": "6.3.0"
+        "@pixi/constants": "6.3.2",
+        "@pixi/settings": "6.3.2"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4613,46 +4613,46 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.0.tgz",
-      "integrity": "sha512-ayOmVagMSa5lPVvznDf2e4EppwzPEDnB/q3AYdjTM9Ksw+JKT3lbLuZFo/6U0HNYF9DsJRJL/4ebReZh1hnqLQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.2.tgz",
+      "integrity": "sha512-XEF59IQRouXCkTSCwNrNvr08/FY3Dai4lwNdrgh5SLeS4Hmn+lNURq2auM+4lYPfsXtQdpZNdJ5iYrFwP41JvA==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.3.0",
-        "@pixi/app": "6.3.0",
-        "@pixi/compressed-textures": "6.3.0",
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/extract": "6.3.0",
-        "@pixi/filter-alpha": "6.3.0",
-        "@pixi/filter-blur": "6.3.0",
-        "@pixi/filter-color-matrix": "6.3.0",
-        "@pixi/filter-displacement": "6.3.0",
-        "@pixi/filter-fxaa": "6.3.0",
-        "@pixi/filter-noise": "6.3.0",
-        "@pixi/graphics": "6.3.0",
-        "@pixi/interaction": "6.3.0",
-        "@pixi/loaders": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/mesh": "6.3.0",
-        "@pixi/mesh-extras": "6.3.0",
-        "@pixi/mixin-cache-as-bitmap": "6.3.0",
-        "@pixi/mixin-get-child-by-name": "6.3.0",
-        "@pixi/mixin-get-global-position": "6.3.0",
-        "@pixi/particle-container": "6.3.0",
-        "@pixi/polyfill": "6.3.0",
-        "@pixi/prepare": "6.3.0",
-        "@pixi/runner": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/sprite-animated": "6.3.0",
-        "@pixi/sprite-tiling": "6.3.0",
-        "@pixi/spritesheet": "6.3.0",
-        "@pixi/text": "6.3.0",
-        "@pixi/text-bitmap": "6.3.0",
-        "@pixi/ticker": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/accessibility": "6.3.2",
+        "@pixi/app": "6.3.2",
+        "@pixi/compressed-textures": "6.3.2",
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/extract": "6.3.2",
+        "@pixi/filter-alpha": "6.3.2",
+        "@pixi/filter-blur": "6.3.2",
+        "@pixi/filter-color-matrix": "6.3.2",
+        "@pixi/filter-displacement": "6.3.2",
+        "@pixi/filter-fxaa": "6.3.2",
+        "@pixi/filter-noise": "6.3.2",
+        "@pixi/graphics": "6.3.2",
+        "@pixi/interaction": "6.3.2",
+        "@pixi/loaders": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/mesh": "6.3.2",
+        "@pixi/mesh-extras": "6.3.2",
+        "@pixi/mixin-cache-as-bitmap": "6.3.2",
+        "@pixi/mixin-get-child-by-name": "6.3.2",
+        "@pixi/mixin-get-global-position": "6.3.2",
+        "@pixi/particle-container": "6.3.2",
+        "@pixi/polyfill": "6.3.2",
+        "@pixi/prepare": "6.3.2",
+        "@pixi/runner": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/sprite-animated": "6.3.2",
+        "@pixi/sprite-tiling": "6.3.2",
+        "@pixi/spritesheet": "6.3.2",
+        "@pixi/text": "6.3.2",
+        "@pixi/text-bitmap": "6.3.2",
+        "@pixi/ticker": "6.3.2",
+        "@pixi/utils": "6.3.2"
       },
       "funding": {
         "type": "opencollective",
@@ -6490,170 +6490,170 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.0.tgz",
-      "integrity": "sha512-G2IJovkixJ3MdXC456e7Nu9J2nLte01KwJPkWhhuuZkRQI6gBcLHn5flGG+QVx/dZDLySXyHiJ+1MAQ8kI9AbA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.2.tgz",
+      "integrity": "sha512-JLDuSGITGEOmR7s0d1Wxj7a3yIp4hP6w2h6ku6iu3clE/bmVtnvhqMX1D1lhjRW/uWUfpVT4U+8CG+LgSsEZ1g==",
       "dev": true,
       "requires": {}
     },
     "@pixi/app": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.0.tgz",
-      "integrity": "sha512-Ud+D/VkGFCx9Z+i0OXDzXqT3zNrUJ9f3sZuoACz1VVD6nnSq+wBZPnyoOOsgfiMYo/0KYVJh+EdBKZS8aYnnVQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.2.tgz",
+      "integrity": "sha512-V1jnhL92OPiquXtLxUeSZiVDd1mtjRnYpBKA958w29MrIRBx3Y6dgnvsaFZGGWBvSL//WRYV23iZKVL/jRGmmQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/compressed-textures": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.0.tgz",
-      "integrity": "sha512-Y/SHGQZftvSM98/m89a1Pf99c9L5TGEPngueOcmjCABeGI33vOaL2VM4chkHXhG9HLqrHYAty24vXqOj42LbJw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.2.tgz",
+      "integrity": "sha512-E/T9WsWcTstnCaDo3GQZUsvX2bE1tZwJ+rUVQ6ad+9MLI6mpUKJFUy5XXlnZw0uiKU5Hipi1ASPQ8/EQ7kKebA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.0.tgz",
-      "integrity": "sha512-295/bb0+5IugA9plqBnD6xrvApjgGRdaNJ6EryCa7UB2j8wt4YtuzLjNeaCtng9eJONgJXXPhPF85+spdWRMbg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.2.tgz",
+      "integrity": "sha512-sUE8QEJNl4vWUybS0YqpVUBWoOyLkr5bSj1+3mpmbWJTMVmLB2voFXo7XpSNCBlLH1SBN5flcgJlUWOCgNyATg==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.0.tgz",
-      "integrity": "sha512-j7UMizcgDoUB9eDrZIP22xJCPYpjx2/BCl8deE5M9Cim9OR2qPxnNnt3jC1oKf2vVnNMTDrMOLekhMVo89FX2Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-91Fw0CbFpPtMKo5TG1wdaZGgR99lX87l15F7kgge7FM7ZR4EghLiJHU8whQ19f/UNOd8AG7mHD84lUB1VXXfoA==",
       "dev": true,
       "requires": {
         "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "@pixi/display": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.0.tgz",
-      "integrity": "sha512-Uxc1aLTFzV55d3kOlh/g19RlE2okPXsroi5jfYGCNS0VCdFk0sp6jMNEwk12BwC0KcA5SU7217H4jLy38VCVpA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.2.tgz",
+      "integrity": "sha512-D+WiM0BcyPK91RYxl7TXXVNz/5lOGs8Q6jtCMcWgTHwCXxWPOHFnNZ4KPJZpUQ7me8Tl2u+c9hfB5Oh1+17r/Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/extract": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.0.tgz",
-      "integrity": "sha512-p5d3Jx0hoIQZsn1msIOyYCzyRjVkfiDUNkuzpLmNo9zng7C6bwqmIZWEMr5alm7+XwqKHlQdsBuK9PeUJt9fGQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.2.tgz",
+      "integrity": "sha512-9DT3EG5dE/+HlSsbWLZ28/+YwGzHwgOPIMLB8AHxDsWYKzDg+SDK53IUE2UIeEiV8AFHwaDT2K+/qPFUUcS0Bw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.0.tgz",
-      "integrity": "sha512-FyO35T2ym7R/rxaQzz3+dfpMlNn7b4XCFebD7hAgYoLqb+/vaM32ZjjoKBxxFRFqpZxBO6BObCyJQd245h+P4A==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.2.tgz",
+      "integrity": "sha512-EhFnGuzUnQ94tosInBlMEOtiDtTAm4ZbWtoSYrH3GP7WORCQB5asWTFsOZv/QxwEbloRbxsDOATVIwS5ZcgNOg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.0.tgz",
-      "integrity": "sha512-TpQxBbFnkcAxMOInMZDprRPXlfhQ0tYOvbnmdDbVTEGOqDXY/7do0bYRfsNshAyeyGE4NVIks1S/RlGkzHLhBg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.2.tgz",
+      "integrity": "sha512-408Z/Rc2LJRg8AaBfzStAph18G0pT3LdLowdTOqPI2s007jgT7wLr9CyWdRe6DdSmPikgnn50R3QG9YeOPWONw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.0.tgz",
-      "integrity": "sha512-9qKrRiaeINap7BgolI3GZ5RaRgYNx0pK8iyrn7vWcuQAxR/lPM+rfgWQPagjXdU9NbnbnfZj0LNOmgFqtWsZTQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.2.tgz",
+      "integrity": "sha512-PRrQWRRUJ3qDqHhqYNcZ8H3tjXyFbIoUGdTOgB1uCNBHmzJ7Cirhs4lWYBBTvtduboUSGvLMpkv0sgFwodPw4Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.0.tgz",
-      "integrity": "sha512-zjOnM3fVh4HOxEHzG/iN00ZmxCuZdxy+xTnjUZkbOgmXtDqRa9HakCBHlg60ZpF/NiIAkJNdrXx6nDhh2hve8Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.2.tgz",
+      "integrity": "sha512-Bda8jY3lVBwlG1GZadYPGXQPO7O+nTt64/KTXQgLtaKB+xj6Me5L7l9IDWtkHEoUTtQK4yCsbkdqKgLKKmNFYg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.0.tgz",
-      "integrity": "sha512-dKhKNmQ8zgtvcT2s7nDU/0LETaCzydgosXAeEPO5XtkHA6asffjEAqiie9wpj3DzODOibNuC/wpiiwGmN6xGgw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.2.tgz",
+      "integrity": "sha512-C5Ga5MJlBFoZUa5oOZEsEEByPzpa+JTRVT7+qQ01g4khU1Mnk/p8JvNm6DYUqw9Y821OR80AmHm2O+r5MkLhcQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.0.tgz",
-      "integrity": "sha512-+2qhb/wWkqI86xb2+NMxeoKUiA5Kx6Kvo1jCvSE4PdP5CGCFDLQqnj0NkIZCbl/3L0MiM9vy+JRmY+nVgre8Tw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.2.tgz",
+      "integrity": "sha512-8lZdccDdlKTNktbD+8aeYfceayV6Rzq1P6NLpbvzFZbxH6JoaaNQb2TQgU+Vl/ZcssBB+IJ8MvJZbLuWKC4CmQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.0.tgz",
-      "integrity": "sha512-cnce8ddZSRgVuwK3hdWjEgf9WJljEXlJp+tOIEYvmNYnkvfaRpdeVRpF5yd+A24ZswrVRU9W/W7cXCMw2uq/vQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.2.tgz",
+      "integrity": "sha512-GaykoXJr0pV0e9TB1yOcgvJf9i/fIF/cgT+DnGz82uninWMo31aFJSvhLbZOcEPQRfdHXdFfUkQAAMTICAp7+Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.0.tgz",
-      "integrity": "sha512-ZAgYJPnpQS07r69o6Mgn4SxurY+t05EWblC8bpVssQ/k2yU3xeWAKNV/Hk39AKrM5S+PBU9YyGX//jM+3gt8rQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.2.tgz",
+      "integrity": "sha512-HZyflufAW1B1cQmQBvzv4IxwcHbqQ0zhHiabSVtwPUHW/nCSpw09hL+k4HR/aFyCdRI/99JcvW5QJp1ldA6OBw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.0.tgz",
-      "integrity": "sha512-FXW3DkcAg2w0FABS6ixmzJNQSdabHXWumltelYM76NmBSE8oaLmg6tniBvjrTlSxUs3HlgwdeqgnUHV9GIFxLQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.2.tgz",
+      "integrity": "sha512-kkm1pynWTslQsh+h+Tw17MdeRMQ37Ht72xiZetyWbxadRAnzj+x1I9juEKEFK62mw8K/bGBcNPhu7edgmQwkvw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/math": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.0.tgz",
-      "integrity": "sha512-QkF9wl3/kXvthwWhrDAVgWQWl3T9dbyicHsoWfx0s9b3E0rx+PZcpz5ftaAVxGd7EvecIxV9nEUnna9TIjvwJQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.2.tgz",
+      "integrity": "sha512-REXrCKQaT2shJ3p2Rpq1ZYV4iUeAOUFKnLN2KteQWtB5HQpB8b+w5xBGI+TcnY0FUhx92fbKPYTTvCftNZF4Jw==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.0.tgz",
-      "integrity": "sha512-ljm1lk8ZyxQaZHl53psPptD7eO8yVt7mbEwly+qSyh61Nj950fq5CBgr2cd7TakBSUfiUthYAYP8wmdwop328Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.2.tgz",
+      "integrity": "sha512-zhfagRDGkJx+H4a+Im3wQbCeS0Av1FyHzvPeBXXQ7LP/giwTnvJhItlhGMwgFllNEAIB47An0ffFEe5CmTcyKw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.0.tgz",
-      "integrity": "sha512-rGvpW/UDNPDSALocT2w3jvBpF9TUgyvZMGcxqolIxDbrmRiyUeT1EeYnCQpIqQUnkKW1QKxLpuSjut2yfERe7A==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.2.tgz",
+      "integrity": "sha512-lODKYkoHqynMK8QxE9ttZ1D+3LnHFG13YL4Yf1W9MGgy1N9G0E5DNB8/Z1BApbRxnRPRg8fsoP2bk5Bn9boWyw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.0.tgz",
-      "integrity": "sha512-KIbclUCTv6J2ERIX8LM0PaGezKqfmDbR8X/68irbwsYU3fRtsFb9X4IHttguiItYK8C6syyepEyIRbWB/poc6Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.2.tgz",
+      "integrity": "sha512-Obqnf3Y2JBOtdewkaGb2oa8SDw3+JZCaOB+x0+pBqDivXpwX2eibS4PaYuGVTIa9FdcrGm9SyLOQlL5irEeEqA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.0.tgz",
-      "integrity": "sha512-R1nh985Fffo0HG3gmbbsBgbR0obGdjkVb31V9gUFileydY8u1jVA4sL1uzOfBbHAjDE+HFOO1wC1p6ygalUrkQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.2.tgz",
+      "integrity": "sha512-R6RJzd1aQ5up5N7uO0boOp99gkSZVEbYKofJNRn1pFdzOmuVCgSqERAv9pQnjp5bBD8JvcKN+PYHPn+k+nTprQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.0.tgz",
-      "integrity": "sha512-hDzLubpLSRH6hp+mn8mpONZeMcMc75ndkz6WROXI0gfoUkFdzxHStGBSk4VJRgtSj1zzOgmEqo7LP/y2blgYlw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.2.tgz",
+      "integrity": "sha512-R7F1sH68fiIvB723doEzE0+k8OfhM5N0H+Ncp8iwLwXxfUDSHVj40nIngMtdK4bLSk29TTczOeXOzXkOAEVXhA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/particle-container": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.0.tgz",
-      "integrity": "sha512-yjcMUHIPUL4T27ECBrxgn6j00CpomYLBvdxXWDDqMSnm2W6AA+cy7QM30dCm2mcbStzB4j+cbYvN1+nRIuIE8Q==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.2.tgz",
+      "integrity": "sha512-iEHtE2AWQ0NZxv57VzfsBbEEp5WXAt91+l2lNvXf1SbzEm/bqjE56Q5bftx9tl3MJlDmOEfPzzKSwIUcZT+T6w==",
       "dev": true,
       "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.0.tgz",
-      "integrity": "sha512-sjOLw0yndRipWOW3ykkCej5+VMZRBmnd32kUXXum9kgceSeL0w+iRPZrfvaFmgypqGnGpqwg24MsZ3vtIffd9g==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.2.tgz",
+      "integrity": "sha512-LTKqL/de7TrBoJNh9netkQofwGBIO3NwwQbqBmP6rHXeaHBx9904Pkuf7GJspIFY09TOo5fnctYnJ1F7LfTljg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -6661,80 +6661,80 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.0.tgz",
-      "integrity": "sha512-eqQpEIAhctZ85YEQWYMI/LmNyLn8K+lpfH783YQQ1WjFmBrFgJzvm1vs+ztIRl+6EIzVIC28RmcBU15Vkmylew==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.2.tgz",
+      "integrity": "sha512-HFV0jUgr5arNBlgctTRqMCgG42vq48J9QLBCZMCRObJQC5325nEXC1toeEekdzqNcGu5bO8/GKeb6+Km2XK2qA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.0.tgz",
-      "integrity": "sha512-dG0YK/59dMay1pBD3sXYWtyDQ1gjRY8QCI38b+wQiH9oFMNFtj/f/RxkL1XyaK0r7sC8TjXUiQ+7+lZlmcqIjw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.2.tgz",
+      "integrity": "sha512-Sspv4VTiV51GwoIg+WudHZHpT3ad5ukW20OLOR+eDOSLbgQEMfj4cTVRg27TvM/QZ/5LxeN3FqwWV+kiWpqCnw==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.0.tgz",
-      "integrity": "sha512-UkbZmlexr6NGM6Qz30Et63bpWAmpmkknOOnavrhWPnnbhFIx4kVzU9mvGMHGSGNLJabX9+gFUdjDGSlzF42v4w==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.2.tgz",
+      "integrity": "sha512-i5cLDUWFnRub3LPa3x7IzkH8MjSwPHyHWzIZKG5t8RiCfbhVfhWGEdKO9AYp8yO/xcf7AqtPK4mikXziL48tXA==",
       "dev": true,
       "requires": {
         "ismobilejs": "^1.1.0"
       }
     },
     "@pixi/sprite": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.0.tgz",
-      "integrity": "sha512-dv0CSkxjWZeUujYQ6NorJ5Cue6SL+RE/H739JK4+cAwEtoWpYqKqiw6aeUu4aqSRsqjhyk9ilhR+K1MbnImJKA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.2.tgz",
+      "integrity": "sha512-T1KJ8l2f8Otn6Se6h4b2pz2nrUSe59Pnmj2WIzgBisM245h7dGATs05MisMaLV6Lg/3gTBTxsLBmKsbDSQqbNw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.0.tgz",
-      "integrity": "sha512-P4VroljvyiAc9acwbUVZTHKwM418x5AFOAEYAx9NkF9izh2HhinjLa+iRK70gPnEBOMPwqn1taVnz/n4/aYHWw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.2.tgz",
+      "integrity": "sha512-fSY64i5BqbOmtFKhgOWf9iML4gId7l5hcniUT/s95+eIZiyYss+jxeekVH22DrAyCOAIdsLEClvGCHGj8iXTFw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.0.tgz",
-      "integrity": "sha512-4+HodD9QwhiqIptBpT3rXuJDAJ5TSg2IRnHOo/+qSopA70VC1E+RRgyVvxfRfopfptcAHi60XWfzvFLHSV3LsA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.2.tgz",
+      "integrity": "sha512-13zsz0xyxMvobEaSXQghSD44+MpSwpbQJYjPVPb7ItqETqQBaZgHpC5uF6vxFR6Hou8Ca8laxRuwgpn3lA095g==",
       "dev": true,
       "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.0.tgz",
-      "integrity": "sha512-TAIIVA2KFJk7lKB4Ggep99bxpkSjnYlODuLEZ9EoJ6QIEx9A1HesaKwwqzfneeCzX5BOBeJMgZ++rujE29rrpg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.2.tgz",
+      "integrity": "sha512-OCi2BUqcBbh2vvbrnLLBOwxFZMQS+rvjW3udBUNbbqUL+NHy74w8N5Ed8pcxXpdfHbApGG6TVJprCGahtmEfJw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.0.tgz",
-      "integrity": "sha512-hDevLv8HztzdImA6sIvmpBpNoIyDCrMNJAdjTUo/Kw1aoKlDaOGx4K3J7wVTzV1d1WrreIXtOsO3rQUOzf/hmg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.2.tgz",
+      "integrity": "sha512-YiPnUBmgZ0WzF0+XMm07iRg0jOyPbIjGmXJ+1srU5L9c3cCzvtg5QuYL0lPHS0Z6gyxhj/6ncePhBGO87RIKnA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.0.tgz",
-      "integrity": "sha512-ogoJ+k7MHUEUb8b+yBZOi9jLW/TvIEduf2FJ5S52sovjhjs1/uZw2sdR43tM9BGxP1W9H6GE5yOK5f2sEFZIKg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.2.tgz",
+      "integrity": "sha512-jvMeIxoAGDlSn5rHimISI9F6fTk8D+GXG0YQraRT9oXb1Ugy/bFJph3XOTe46s4oZ5R5QeCLQmo6k7TUIvbSkA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.0.tgz",
-      "integrity": "sha512-cEqyQgM5entsi+h85fUnESBzNc/yMRG/mqsfAr7/KraP7bmCcn3MYVuTycRMkRbuNPjC1NIpqkqiOaxzgAUGPw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.2.tgz",
+      "integrity": "sha512-Au9IO85zCOOCz50aJALFxJ2C8gbgxvD0dSNm7A5FauanJbxDcctIyrW6I51nNyHyeLIUFEkuD2jE/DmcXsXnpw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.0.tgz",
-      "integrity": "sha512-QI5wb/fDdH8DAzIMlrYS0MhG382FPMLh4s3yRtOaftiOb84LL7Syz//SC+CJAyVB0UV/Lpr+T6PiCa4eBjRDgA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.2.tgz",
+      "integrity": "sha512-VpB403kfqwXK9w7Qb6ex0aW0g6pWI/t43F2Z8CA/lAfYcN3O0XoxDucvmkLTQWsMtYn+Yf7YhAcLV5SemKwP0A==",
       "dev": true,
       "requires": {
         "@types/earcut": "^2.1.0",
@@ -8957,46 +8957,46 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.0.tgz",
-      "integrity": "sha512-ayOmVagMSa5lPVvznDf2e4EppwzPEDnB/q3AYdjTM9Ksw+JKT3lbLuZFo/6U0HNYF9DsJRJL/4ebReZh1hnqLQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.2.tgz",
+      "integrity": "sha512-XEF59IQRouXCkTSCwNrNvr08/FY3Dai4lwNdrgh5SLeS4Hmn+lNURq2auM+4lYPfsXtQdpZNdJ5iYrFwP41JvA==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.3.0",
-        "@pixi/app": "6.3.0",
-        "@pixi/compressed-textures": "6.3.0",
-        "@pixi/constants": "6.3.0",
-        "@pixi/core": "6.3.0",
-        "@pixi/display": "6.3.0",
-        "@pixi/extract": "6.3.0",
-        "@pixi/filter-alpha": "6.3.0",
-        "@pixi/filter-blur": "6.3.0",
-        "@pixi/filter-color-matrix": "6.3.0",
-        "@pixi/filter-displacement": "6.3.0",
-        "@pixi/filter-fxaa": "6.3.0",
-        "@pixi/filter-noise": "6.3.0",
-        "@pixi/graphics": "6.3.0",
-        "@pixi/interaction": "6.3.0",
-        "@pixi/loaders": "6.3.0",
-        "@pixi/math": "6.3.0",
-        "@pixi/mesh": "6.3.0",
-        "@pixi/mesh-extras": "6.3.0",
-        "@pixi/mixin-cache-as-bitmap": "6.3.0",
-        "@pixi/mixin-get-child-by-name": "6.3.0",
-        "@pixi/mixin-get-global-position": "6.3.0",
-        "@pixi/particle-container": "6.3.0",
-        "@pixi/polyfill": "6.3.0",
-        "@pixi/prepare": "6.3.0",
-        "@pixi/runner": "6.3.0",
-        "@pixi/settings": "6.3.0",
-        "@pixi/sprite": "6.3.0",
-        "@pixi/sprite-animated": "6.3.0",
-        "@pixi/sprite-tiling": "6.3.0",
-        "@pixi/spritesheet": "6.3.0",
-        "@pixi/text": "6.3.0",
-        "@pixi/text-bitmap": "6.3.0",
-        "@pixi/ticker": "6.3.0",
-        "@pixi/utils": "6.3.0"
+        "@pixi/accessibility": "6.3.2",
+        "@pixi/app": "6.3.2",
+        "@pixi/compressed-textures": "6.3.2",
+        "@pixi/constants": "6.3.2",
+        "@pixi/core": "6.3.2",
+        "@pixi/display": "6.3.2",
+        "@pixi/extract": "6.3.2",
+        "@pixi/filter-alpha": "6.3.2",
+        "@pixi/filter-blur": "6.3.2",
+        "@pixi/filter-color-matrix": "6.3.2",
+        "@pixi/filter-displacement": "6.3.2",
+        "@pixi/filter-fxaa": "6.3.2",
+        "@pixi/filter-noise": "6.3.2",
+        "@pixi/graphics": "6.3.2",
+        "@pixi/interaction": "6.3.2",
+        "@pixi/loaders": "6.3.2",
+        "@pixi/math": "6.3.2",
+        "@pixi/mesh": "6.3.2",
+        "@pixi/mesh-extras": "6.3.2",
+        "@pixi/mixin-cache-as-bitmap": "6.3.2",
+        "@pixi/mixin-get-child-by-name": "6.3.2",
+        "@pixi/mixin-get-global-position": "6.3.2",
+        "@pixi/particle-container": "6.3.2",
+        "@pixi/polyfill": "6.3.2",
+        "@pixi/prepare": "6.3.2",
+        "@pixi/runner": "6.3.2",
+        "@pixi/settings": "6.3.2",
+        "@pixi/sprite": "6.3.2",
+        "@pixi/sprite-animated": "6.3.2",
+        "@pixi/sprite-tiling": "6.3.2",
+        "@pixi/spritesheet": "6.3.2",
+        "@pixi/text": "6.3.2",
+        "@pixi/text-bitmap": "6.3.2",
+        "@pixi/ticker": "6.3.2",
+        "@pixi/utils": "6.3.2"
       }
     },
     "pkg-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
         "eslint": "^8.57.0",
         "eslint-plugin-disable-autofix": "^4.2.0",
         "jest": "^29.3.1",
-        "pixi.js": "^6.2.0",
+        "pixi.js": "^6.3.0",
         "ts-jest": "^29.0.5",
         "typescript": "^4.2.3"
       },
       "peerDependencies": {
-        "pixi.js": "^6.2.0 || ^7.0.0 || ^8.0.0"
+        "pixi.js": "^6.3.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1227,51 +1227,48 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
-      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.0.tgz",
+      "integrity": "sha512-G2IJovkixJ3MdXC456e7Nu9J2nLte01KwJPkWhhuuZkRQI6gBcLHn5flGG+QVx/dZDLySXyHiJ+1MAQ8kI9AbA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
-      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.0.tgz",
+      "integrity": "sha512-Ud+D/VkGFCx9Z+i0OXDzXqT3zNrUJ9f3sZuoACz1VVD6nnSq+wBZPnyoOOsgfiMYo/0KYVJh+EdBKZS8aYnnVQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
-      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.0.tgz",
+      "integrity": "sha512-Y/SHGQZftvSM98/m89a1Pf99c9L5TGEPngueOcmjCABeGI33vOaL2VM4chkHXhG9HLqrHYAty24vXqOj42LbJw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/loaders": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
-      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.0.tgz",
+      "integrity": "sha512-295/bb0+5IugA9plqBnD6xrvApjgGRdaNJ6EryCa7UB2j8wt4YtuzLjNeaCtng9eJONgJXXPhPF85+spdWRMbg==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
-      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-j7UMizcgDoUB9eDrZIP22xJCPYpjx2/BCl8deE5M9Cim9OR2qPxnNnt3jC1oKf2vVnNMTDrMOLekhMVo89FX2Q==",
       "dev": true,
       "dependencies": {
         "@types/offscreencanvas": "^2019.6.4"
@@ -1281,225 +1278,213 @@
         "url": "https://opencollective.com/pixijs"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/runner": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/ticker": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
-      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.0.tgz",
+      "integrity": "sha512-Uxc1aLTFzV55d3kOlh/g19RlE2okPXsroi5jfYGCNS0VCdFk0sp6jMNEwk12BwC0KcA5SU7217H4jLy38VCVpA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/math": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
-    "node_modules/@pixi/extensions": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
-      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "dev": true
-    },
     "node_modules/@pixi/extract": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
-      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.0.tgz",
+      "integrity": "sha512-p5d3Jx0hoIQZsn1msIOyYCzyRjVkfiDUNkuzpLmNo9zng7C6bwqmIZWEMr5alm7+XwqKHlQdsBuK9PeUJt9fGQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
-      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.0.tgz",
+      "integrity": "sha512-FyO35T2ym7R/rxaQzz3+dfpMlNn7b4XCFebD7hAgYoLqb+/vaM32ZjjoKBxxFRFqpZxBO6BObCyJQd245h+P4A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
-      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.0.tgz",
+      "integrity": "sha512-TpQxBbFnkcAxMOInMZDprRPXlfhQ0tYOvbnmdDbVTEGOqDXY/7do0bYRfsNshAyeyGE4NVIks1S/RlGkzHLhBg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/settings": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
-      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.0.tgz",
+      "integrity": "sha512-9qKrRiaeINap7BgolI3GZ5RaRgYNx0pK8iyrn7vWcuQAxR/lPM+rfgWQPagjXdU9NbnbnfZj0LNOmgFqtWsZTQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
-      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.0.tgz",
+      "integrity": "sha512-zjOnM3fVh4HOxEHzG/iN00ZmxCuZdxy+xTnjUZkbOgmXtDqRa9HakCBHlg60ZpF/NiIAkJNdrXx6nDhh2hve8Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/math": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
-      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.0.tgz",
+      "integrity": "sha512-dKhKNmQ8zgtvcT2s7nDU/0LETaCzydgosXAeEPO5XtkHA6asffjEAqiie9wpj3DzODOibNuC/wpiiwGmN6xGgw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.3.0"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
-      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.0.tgz",
+      "integrity": "sha512-+2qhb/wWkqI86xb2+NMxeoKUiA5Kx6Kvo1jCvSE4PdP5CGCFDLQqnj0NkIZCbl/3L0MiM9vy+JRmY+nVgre8Tw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.3.0"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
-      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.0.tgz",
+      "integrity": "sha512-cnce8ddZSRgVuwK3hdWjEgf9WJljEXlJp+tOIEYvmNYnkvfaRpdeVRpF5yd+A24ZswrVRU9W/W7cXCMw2uq/vQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
-      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.0.tgz",
+      "integrity": "sha512-ZAgYJPnpQS07r69o6Mgn4SxurY+t05EWblC8bpVssQ/k2yU3xeWAKNV/Hk39AKrM5S+PBU9YyGX//jM+3gt8rQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/ticker": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
-      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.0.tgz",
+      "integrity": "sha512-FXW3DkcAg2w0FABS6ixmzJNQSdabHXWumltelYM76NmBSE8oaLmg6tniBvjrTlSxUs3HlgwdeqgnUHV9GIFxLQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
-      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.0.tgz",
+      "integrity": "sha512-QkF9wl3/kXvthwWhrDAVgWQWl3T9dbyicHsoWfx0s9b3E0rx+PZcpz5ftaAVxGd7EvecIxV9nEUnna9TIjvwJQ==",
       "dev": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
-      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.0.tgz",
+      "integrity": "sha512-ljm1lk8ZyxQaZHl53psPptD7eO8yVt7mbEwly+qSyh61Nj950fq5CBgr2cd7TakBSUfiUthYAYP8wmdwop328Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
-      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.0.tgz",
+      "integrity": "sha512-rGvpW/UDNPDSALocT2w3jvBpF9TUgyvZMGcxqolIxDbrmRiyUeT1EeYnCQpIqQUnkKW1QKxLpuSjut2yfERe7A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/mesh": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
-      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.0.tgz",
+      "integrity": "sha512-KIbclUCTv6J2ERIX8LM0PaGezKqfmDbR8X/68irbwsYU3fRtsFb9X4IHttguiItYK8C6syyepEyIRbWB/poc6Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
-      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.0.tgz",
+      "integrity": "sha512-R1nh985Fffo0HG3gmbbsBgbR0obGdjkVb31V9gUFileydY8u1jVA4sL1uzOfBbHAjDE+HFOO1wC1p6ygalUrkQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.5.10"
+        "@pixi/display": "6.3.0"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
-      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.0.tgz",
+      "integrity": "sha512-hDzLubpLSRH6hp+mn8mpONZeMcMc75ndkz6WROXI0gfoUkFdzxHStGBSk4VJRgtSj1zzOgmEqo7LP/y2blgYlw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10"
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0"
       }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
-      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.0.tgz",
+      "integrity": "sha512-yjcMUHIPUL4T27ECBrxgn6j00CpomYLBvdxXWDDqMSnm2W6AA+cy7QM30dCm2mcbStzB4j+cbYvN1+nRIuIE8Q==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
-      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.0.tgz",
+      "integrity": "sha512-sjOLw0yndRipWOW3ykkCej5+VMZRBmnd32kUXXum9kgceSeL0w+iRPZrfvaFmgypqGnGpqwg24MsZ3vtIffd9g==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -1507,140 +1492,138 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
-      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.0.tgz",
+      "integrity": "sha512-eqQpEIAhctZ85YEQWYMI/LmNyLn8K+lpfH783YQQ1WjFmBrFgJzvm1vs+ztIRl+6EIzVIC28RmcBU15Vkmylew==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/graphics": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/text": "6.3.0",
+        "@pixi/ticker": "6.3.0"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
-      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.0.tgz",
+      "integrity": "sha512-dG0YK/59dMay1pBD3sXYWtyDQ1gjRY8QCI38b+wQiH9oFMNFtj/f/RxkL1XyaK0r7sC8TjXUiQ+7+lZlmcqIjw==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
-      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.0.tgz",
+      "integrity": "sha512-UkbZmlexr6NGM6Qz30Et63bpWAmpmkknOOnavrhWPnnbhFIx4kVzU9mvGMHGSGNLJabX9+gFUdjDGSlzF42v4w==",
       "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10"
+      "dependencies": {
+        "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
-      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.0.tgz",
+      "integrity": "sha512-dv0CSkxjWZeUujYQ6NorJ5Cue6SL+RE/H739JK4+cAwEtoWpYqKqiw6aeUu4aqSRsqjhyk9ilhR+K1MbnImJKA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
-      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.0.tgz",
+      "integrity": "sha512-P4VroljvyiAc9acwbUVZTHKwM418x5AFOAEYAx9NkF9izh2HhinjLa+iRK70gPnEBOMPwqn1taVnz/n4/aYHWw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/ticker": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/ticker": "6.3.0"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
-      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.0.tgz",
+      "integrity": "sha512-4+HodD9QwhiqIptBpT3rXuJDAJ5TSg2IRnHOo/+qSopA70VC1E+RRgyVvxfRfopfptcAHi60XWfzvFLHSV3LsA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
-      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.0.tgz",
+      "integrity": "sha512-TAIIVA2KFJk7lKB4Ggep99bxpkSjnYlODuLEZ9EoJ6QIEx9A1HesaKwwqzfneeCzX5BOBeJMgZ++rujE29rrpg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/loaders": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
-      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.0.tgz",
+      "integrity": "sha512-hDevLv8HztzdImA6sIvmpBpNoIyDCrMNJAdjTUo/Kw1aoKlDaOGx4K3J7wVTzV1d1WrreIXtOsO3rQUOzf/hmg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
-      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.0.tgz",
+      "integrity": "sha512-ogoJ+k7MHUEUb8b+yBZOi9jLW/TvIEduf2FJ5S52sovjhjs1/uZw2sdR43tM9BGxP1W9H6GE5yOK5f2sEFZIKg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/loaders": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/mesh": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/text": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
-      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.0.tgz",
+      "integrity": "sha512-cEqyQgM5entsi+h85fUnESBzNc/yMRG/mqsfAr7/KraP7bmCcn3MYVuTycRMkRbuNPjC1NIpqkqiOaxzgAUGPw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/extensions": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/settings": "6.3.0"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
-      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.0.tgz",
+      "integrity": "sha512-QI5wb/fDdH8DAzIMlrYS0MhG382FPMLh4s3yRtOaftiOb84LL7Syz//SC+CJAyVB0UV/Lpr+T6PiCa4eBjRDgA==",
       "dev": true,
       "dependencies": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/constants": "6.3.0",
+        "@pixi/settings": "6.3.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -3524,6 +3507,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "dev": true
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4624,47 +4613,46 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
-      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.0.tgz",
+      "integrity": "sha512-ayOmVagMSa5lPVvznDf2e4EppwzPEDnB/q3AYdjTM9Ksw+JKT3lbLuZFo/6U0HNYF9DsJRJL/4ebReZh1hnqLQ==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.5.10",
-        "@pixi/app": "6.5.10",
-        "@pixi/compressed-textures": "6.5.10",
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/extract": "6.5.10",
-        "@pixi/filter-alpha": "6.5.10",
-        "@pixi/filter-blur": "6.5.10",
-        "@pixi/filter-color-matrix": "6.5.10",
-        "@pixi/filter-displacement": "6.5.10",
-        "@pixi/filter-fxaa": "6.5.10",
-        "@pixi/filter-noise": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/interaction": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/mesh-extras": "6.5.10",
-        "@pixi/mixin-cache-as-bitmap": "6.5.10",
-        "@pixi/mixin-get-child-by-name": "6.5.10",
-        "@pixi/mixin-get-global-position": "6.5.10",
-        "@pixi/particle-container": "6.5.10",
-        "@pixi/polyfill": "6.5.10",
-        "@pixi/prepare": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/sprite-animated": "6.5.10",
-        "@pixi/sprite-tiling": "6.5.10",
-        "@pixi/spritesheet": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/text-bitmap": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/accessibility": "6.3.0",
+        "@pixi/app": "6.3.0",
+        "@pixi/compressed-textures": "6.3.0",
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/extract": "6.3.0",
+        "@pixi/filter-alpha": "6.3.0",
+        "@pixi/filter-blur": "6.3.0",
+        "@pixi/filter-color-matrix": "6.3.0",
+        "@pixi/filter-displacement": "6.3.0",
+        "@pixi/filter-fxaa": "6.3.0",
+        "@pixi/filter-noise": "6.3.0",
+        "@pixi/graphics": "6.3.0",
+        "@pixi/interaction": "6.3.0",
+        "@pixi/loaders": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/mesh": "6.3.0",
+        "@pixi/mesh-extras": "6.3.0",
+        "@pixi/mixin-cache-as-bitmap": "6.3.0",
+        "@pixi/mixin-get-child-by-name": "6.3.0",
+        "@pixi/mixin-get-global-position": "6.3.0",
+        "@pixi/particle-container": "6.3.0",
+        "@pixi/polyfill": "6.3.0",
+        "@pixi/prepare": "6.3.0",
+        "@pixi/runner": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/sprite-animated": "6.3.0",
+        "@pixi/sprite-tiling": "6.3.0",
+        "@pixi/spritesheet": "6.3.0",
+        "@pixi/text": "6.3.0",
+        "@pixi/text-bitmap": "6.3.0",
+        "@pixi/ticker": "6.3.0",
+        "@pixi/utils": "6.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6502,176 +6490,170 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
-      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.3.0.tgz",
+      "integrity": "sha512-G2IJovkixJ3MdXC456e7Nu9J2nLte01KwJPkWhhuuZkRQI6gBcLHn5flGG+QVx/dZDLySXyHiJ+1MAQ8kI9AbA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/app": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
-      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.3.0.tgz",
+      "integrity": "sha512-Ud+D/VkGFCx9Z+i0OXDzXqT3zNrUJ9f3sZuoACz1VVD6nnSq+wBZPnyoOOsgfiMYo/0KYVJh+EdBKZS8aYnnVQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/compressed-textures": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
-      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.3.0.tgz",
+      "integrity": "sha512-Y/SHGQZftvSM98/m89a1Pf99c9L5TGEPngueOcmjCABeGI33vOaL2VM4chkHXhG9HLqrHYAty24vXqOj42LbJw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
-      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.3.0.tgz",
+      "integrity": "sha512-295/bb0+5IugA9plqBnD6xrvApjgGRdaNJ6EryCa7UB2j8wt4YtuzLjNeaCtng9eJONgJXXPhPF85+spdWRMbg==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
-      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-j7UMizcgDoUB9eDrZIP22xJCPYpjx2/BCl8deE5M9Cim9OR2qPxnNnt3jC1oKf2vVnNMTDrMOLekhMVo89FX2Q==",
       "dev": true,
       "requires": {
         "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "@pixi/display": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
-      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.3.0.tgz",
+      "integrity": "sha512-Uxc1aLTFzV55d3kOlh/g19RlE2okPXsroi5jfYGCNS0VCdFk0sp6jMNEwk12BwC0KcA5SU7217H4jLy38VCVpA==",
       "dev": true,
       "requires": {}
     },
-    "@pixi/extensions": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
-      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "dev": true
-    },
     "@pixi/extract": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
-      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.3.0.tgz",
+      "integrity": "sha512-p5d3Jx0hoIQZsn1msIOyYCzyRjVkfiDUNkuzpLmNo9zng7C6bwqmIZWEMr5alm7+XwqKHlQdsBuK9PeUJt9fGQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
-      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.3.0.tgz",
+      "integrity": "sha512-FyO35T2ym7R/rxaQzz3+dfpMlNn7b4XCFebD7hAgYoLqb+/vaM32ZjjoKBxxFRFqpZxBO6BObCyJQd245h+P4A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
-      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.3.0.tgz",
+      "integrity": "sha512-TpQxBbFnkcAxMOInMZDprRPXlfhQ0tYOvbnmdDbVTEGOqDXY/7do0bYRfsNshAyeyGE4NVIks1S/RlGkzHLhBg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
-      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.3.0.tgz",
+      "integrity": "sha512-9qKrRiaeINap7BgolI3GZ5RaRgYNx0pK8iyrn7vWcuQAxR/lPM+rfgWQPagjXdU9NbnbnfZj0LNOmgFqtWsZTQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
-      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.3.0.tgz",
+      "integrity": "sha512-zjOnM3fVh4HOxEHzG/iN00ZmxCuZdxy+xTnjUZkbOgmXtDqRa9HakCBHlg60ZpF/NiIAkJNdrXx6nDhh2hve8Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
-      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.3.0.tgz",
+      "integrity": "sha512-dKhKNmQ8zgtvcT2s7nDU/0LETaCzydgosXAeEPO5XtkHA6asffjEAqiie9wpj3DzODOibNuC/wpiiwGmN6xGgw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
-      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.3.0.tgz",
+      "integrity": "sha512-+2qhb/wWkqI86xb2+NMxeoKUiA5Kx6Kvo1jCvSE4PdP5CGCFDLQqnj0NkIZCbl/3L0MiM9vy+JRmY+nVgre8Tw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
-      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.3.0.tgz",
+      "integrity": "sha512-cnce8ddZSRgVuwK3hdWjEgf9WJljEXlJp+tOIEYvmNYnkvfaRpdeVRpF5yd+A24ZswrVRU9W/W7cXCMw2uq/vQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
-      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.3.0.tgz",
+      "integrity": "sha512-ZAgYJPnpQS07r69o6Mgn4SxurY+t05EWblC8bpVssQ/k2yU3xeWAKNV/Hk39AKrM5S+PBU9YyGX//jM+3gt8rQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
-      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.3.0.tgz",
+      "integrity": "sha512-FXW3DkcAg2w0FABS6ixmzJNQSdabHXWumltelYM76NmBSE8oaLmg6tniBvjrTlSxUs3HlgwdeqgnUHV9GIFxLQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/math": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
-      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.3.0.tgz",
+      "integrity": "sha512-QkF9wl3/kXvthwWhrDAVgWQWl3T9dbyicHsoWfx0s9b3E0rx+PZcpz5ftaAVxGd7EvecIxV9nEUnna9TIjvwJQ==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
-      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.3.0.tgz",
+      "integrity": "sha512-ljm1lk8ZyxQaZHl53psPptD7eO8yVt7mbEwly+qSyh61Nj950fq5CBgr2cd7TakBSUfiUthYAYP8wmdwop328Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
-      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.3.0.tgz",
+      "integrity": "sha512-rGvpW/UDNPDSALocT2w3jvBpF9TUgyvZMGcxqolIxDbrmRiyUeT1EeYnCQpIqQUnkKW1QKxLpuSjut2yfERe7A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
-      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.3.0.tgz",
+      "integrity": "sha512-KIbclUCTv6J2ERIX8LM0PaGezKqfmDbR8X/68irbwsYU3fRtsFb9X4IHttguiItYK8C6syyepEyIRbWB/poc6Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
-      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.3.0.tgz",
+      "integrity": "sha512-R1nh985Fffo0HG3gmbbsBgbR0obGdjkVb31V9gUFileydY8u1jVA4sL1uzOfBbHAjDE+HFOO1wC1p6ygalUrkQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
-      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.3.0.tgz",
+      "integrity": "sha512-hDzLubpLSRH6hp+mn8mpONZeMcMc75ndkz6WROXI0gfoUkFdzxHStGBSk4VJRgtSj1zzOgmEqo7LP/y2blgYlw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/particle-container": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
-      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.3.0.tgz",
+      "integrity": "sha512-yjcMUHIPUL4T27ECBrxgn6j00CpomYLBvdxXWDDqMSnm2W6AA+cy7QM30dCm2mcbStzB4j+cbYvN1+nRIuIE8Q==",
       "dev": true,
       "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
-      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.3.0.tgz",
+      "integrity": "sha512-sjOLw0yndRipWOW3ykkCej5+VMZRBmnd32kUXXum9kgceSeL0w+iRPZrfvaFmgypqGnGpqwg24MsZ3vtIffd9g==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -6679,82 +6661,84 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
-      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.3.0.tgz",
+      "integrity": "sha512-eqQpEIAhctZ85YEQWYMI/LmNyLn8K+lpfH783YQQ1WjFmBrFgJzvm1vs+ztIRl+6EIzVIC28RmcBU15Vkmylew==",
       "dev": true,
       "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
-      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.3.0.tgz",
+      "integrity": "sha512-dG0YK/59dMay1pBD3sXYWtyDQ1gjRY8QCI38b+wQiH9oFMNFtj/f/RxkL1XyaK0r7sC8TjXUiQ+7+lZlmcqIjw==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
-      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.3.0.tgz",
+      "integrity": "sha512-UkbZmlexr6NGM6Qz30Et63bpWAmpmkknOOnavrhWPnnbhFIx4kVzU9mvGMHGSGNLJabX9+gFUdjDGSlzF42v4w==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ismobilejs": "^1.1.0"
+      }
     },
     "@pixi/sprite": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
-      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.3.0.tgz",
+      "integrity": "sha512-dv0CSkxjWZeUujYQ6NorJ5Cue6SL+RE/H739JK4+cAwEtoWpYqKqiw6aeUu4aqSRsqjhyk9ilhR+K1MbnImJKA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
-      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.3.0.tgz",
+      "integrity": "sha512-P4VroljvyiAc9acwbUVZTHKwM418x5AFOAEYAx9NkF9izh2HhinjLa+iRK70gPnEBOMPwqn1taVnz/n4/aYHWw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
-      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.3.0.tgz",
+      "integrity": "sha512-4+HodD9QwhiqIptBpT3rXuJDAJ5TSg2IRnHOo/+qSopA70VC1E+RRgyVvxfRfopfptcAHi60XWfzvFLHSV3LsA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
-      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.3.0.tgz",
+      "integrity": "sha512-TAIIVA2KFJk7lKB4Ggep99bxpkSjnYlODuLEZ9EoJ6QIEx9A1HesaKwwqzfneeCzX5BOBeJMgZ++rujE29rrpg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
-      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.3.0.tgz",
+      "integrity": "sha512-hDevLv8HztzdImA6sIvmpBpNoIyDCrMNJAdjTUo/Kw1aoKlDaOGx4K3J7wVTzV1d1WrreIXtOsO3rQUOzf/hmg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
-      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.3.0.tgz",
+      "integrity": "sha512-ogoJ+k7MHUEUb8b+yBZOi9jLW/TvIEduf2FJ5S52sovjhjs1/uZw2sdR43tM9BGxP1W9H6GE5yOK5f2sEFZIKg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
-      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.3.0.tgz",
+      "integrity": "sha512-cEqyQgM5entsi+h85fUnESBzNc/yMRG/mqsfAr7/KraP7bmCcn3MYVuTycRMkRbuNPjC1NIpqkqiOaxzgAUGPw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
-      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.3.0.tgz",
+      "integrity": "sha512-QI5wb/fDdH8DAzIMlrYS0MhG382FPMLh4s3yRtOaftiOb84LL7Syz//SC+CJAyVB0UV/Lpr+T6PiCa4eBjRDgA==",
       "dev": true,
       "requires": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -8128,6 +8112,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "dev": true
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8967,47 +8957,46 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
-      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.3.0.tgz",
+      "integrity": "sha512-ayOmVagMSa5lPVvznDf2e4EppwzPEDnB/q3AYdjTM9Ksw+JKT3lbLuZFo/6U0HNYF9DsJRJL/4ebReZh1hnqLQ==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.5.10",
-        "@pixi/app": "6.5.10",
-        "@pixi/compressed-textures": "6.5.10",
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/extract": "6.5.10",
-        "@pixi/filter-alpha": "6.5.10",
-        "@pixi/filter-blur": "6.5.10",
-        "@pixi/filter-color-matrix": "6.5.10",
-        "@pixi/filter-displacement": "6.5.10",
-        "@pixi/filter-fxaa": "6.5.10",
-        "@pixi/filter-noise": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/interaction": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/mesh-extras": "6.5.10",
-        "@pixi/mixin-cache-as-bitmap": "6.5.10",
-        "@pixi/mixin-get-child-by-name": "6.5.10",
-        "@pixi/mixin-get-global-position": "6.5.10",
-        "@pixi/particle-container": "6.5.10",
-        "@pixi/polyfill": "6.5.10",
-        "@pixi/prepare": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/sprite-animated": "6.5.10",
-        "@pixi/sprite-tiling": "6.5.10",
-        "@pixi/spritesheet": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/text-bitmap": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/accessibility": "6.3.0",
+        "@pixi/app": "6.3.0",
+        "@pixi/compressed-textures": "6.3.0",
+        "@pixi/constants": "6.3.0",
+        "@pixi/core": "6.3.0",
+        "@pixi/display": "6.3.0",
+        "@pixi/extract": "6.3.0",
+        "@pixi/filter-alpha": "6.3.0",
+        "@pixi/filter-blur": "6.3.0",
+        "@pixi/filter-color-matrix": "6.3.0",
+        "@pixi/filter-displacement": "6.3.0",
+        "@pixi/filter-fxaa": "6.3.0",
+        "@pixi/filter-noise": "6.3.0",
+        "@pixi/graphics": "6.3.0",
+        "@pixi/interaction": "6.3.0",
+        "@pixi/loaders": "6.3.0",
+        "@pixi/math": "6.3.0",
+        "@pixi/mesh": "6.3.0",
+        "@pixi/mesh-extras": "6.3.0",
+        "@pixi/mixin-cache-as-bitmap": "6.3.0",
+        "@pixi/mixin-get-child-by-name": "6.3.0",
+        "@pixi/mixin-get-global-position": "6.3.0",
+        "@pixi/particle-container": "6.3.0",
+        "@pixi/polyfill": "6.3.0",
+        "@pixi/prepare": "6.3.0",
+        "@pixi/runner": "6.3.0",
+        "@pixi/settings": "6.3.0",
+        "@pixi/sprite": "6.3.0",
+        "@pixi/sprite-animated": "6.3.0",
+        "@pixi/sprite-tiling": "6.3.0",
+        "@pixi/spritesheet": "6.3.0",
+        "@pixi/text": "6.3.0",
+        "@pixi/text-bitmap": "6.3.0",
+        "@pixi/ticker": "6.3.0",
+        "@pixi/utils": "6.3.0"
       }
     },
     "pkg-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,279 +1227,277 @@
       }
     },
     "node_modules/@pixi/accessibility": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
-      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.1.0.tgz",
+      "integrity": "sha512-SDbu08F0eXTc5jqkJdLoX5G6yrSD68V5X7nU9+AfVL5mYdR+wkAuDXjcOINbGq2vxHPN6fgoBNZIDNPfRHeATw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/canvas-renderer": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/app": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
-      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.1.0.tgz",
+      "integrity": "sha512-QIMNyMpswWAIXo1RhTbnem7DEdNnrYCV8RLK9E9nZ3NlzP3587IuMEmNfwZp7PsvMJXehH2opY/hlYxVOmYxew==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0"
+      }
+    },
+    "node_modules/@pixi/canvas-renderer": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.1.0.tgz",
+      "integrity": "sha512-dukgaw9OQyFjTZZ/R2jvf+cyxVQA7P+wJVtGO4Ev/TlaLs85KKy1xtnRpgYbF/etPhORRgN232H6rys50B0YjQ==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/compressed-textures": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
-      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.1.0.tgz",
+      "integrity": "sha512-3Go+GT43avgzyX4+fFYiTEfjR5pHrzafKpVlMvttC9xGRhMV1BZFDi1rKjHYuYk8SgNycuqRa2RulsoVq0bQUw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/loaders": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
-      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.1.0.tgz",
+      "integrity": "sha512-4mIvvyiovu/tT1m32fQO/pYwGxO/ch9ZGOArAcsVKx0gWEk/Whi0fuJVxgCemu8gpSFkcIJreWnOiLUzZCVpdQ==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
-      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-u6pXk8K05ZLhFNQxg+mtlHA6IjV0+lr/IDrEbx55eDZo+ImJwI4ummkJ/uiXaNn04GG0tVAQt+y5+e3fJjVFEQ==",
       "dev": true,
-      "dependencies": {
-        "@types/offscreencanvas": "^2019.6.4"
-      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/runner": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/ticker": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
-      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.1.0.tgz",
+      "integrity": "sha512-Jb1V54kpJXiGjKFx1qe5NhZyl1u6Z1t3o6mWawIFbXKiOJs+nkouUqRyPX2877cu1zkufbAalEe5V8WXOkqixg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
-    "node_modules/@pixi/extensions": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
-      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "dev": true
-    },
     "node_modules/@pixi/extract": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
-      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.1.0.tgz",
+      "integrity": "sha512-QqOb9jZ473mt8NDuAnfD/oUuXefspGLOoVTfHD+NVRP0J3P4Mnzq98ljHHpOFII/XgM8Jam6YRuOlTGyT7H+vg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-alpha": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
-      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.1.0.tgz",
+      "integrity": "sha512-giNst0xR8h3Ulkk3u6JEN8L1TmZsE5JEPZ+brvdZ336k6wiRMxkqIZ2wt1w9cQLq3PY3MAiUO+SZkYr4Zr1GJg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-blur": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
-      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.1.0.tgz",
+      "integrity": "sha512-EskO2DjKGyOwSMQIqVkONJgG8rdF7Ja9EtBBuWGL6V+lE7DUQ0I25+D13+12HD3OMUsEnXyZWmlYtGW9BD9P7g==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/settings": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-color-matrix": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
-      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.1.0.tgz",
+      "integrity": "sha512-8OE8EDyV8KEUhcqwQxeNvW6r0YMBrQXS7IZLUlCvIVdM5rI24qBA1n9ec5w8ofe7A6jdMArmV4NwiNiSHCkYvw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-displacement": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
-      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.1.0.tgz",
+      "integrity": "sha512-ZmsLEYhLQLxVbhP688ofv0bmfRXObYk2Xa3ORwKgivyJeX3UqizP+OUHa1mJ+4n6Q50BwtCra/Cg+TJ0q2R0wQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/math": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-fxaa": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
-      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.1.0.tgz",
+      "integrity": "sha512-htFHMvW7GId9UTw5c8Mdd4FU3RGTg9aSsQ04yQCJekm54pwQsTGzkbElGTVWHznurflOhjAJJRib6dtWW1CY8A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.1.0"
       }
     },
     "node_modules/@pixi/filter-noise": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
-      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.1.0.tgz",
+      "integrity": "sha512-5qdW1UZOcN8pJsyp/L7qNzGvigGwKB0c+RvI9LKWn/DsWC4WfAhatMtKV7dTsYNSRE+MWaFbelBQZT6wYw05Jg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10"
+        "@pixi/core": "6.1.0"
       }
     },
     "node_modules/@pixi/graphics": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
-      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.1.0.tgz",
+      "integrity": "sha512-NfbVX/TIXYrzUDItrXCg6c9LKM6Td1O+xXFnM9uP6EQQ1cyH5uUHtkSR0xgnPpdcs8IEa/FgyOmABEJ+G17syA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/interaction": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
-      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.1.0.tgz",
+      "integrity": "sha512-0GijG3v7oWET96FaFC59ozNrXa5D/fROpZSh2ywwL0NRvftLcjHOSDMGxDXhrlfpsjPgLVqDQQUHAcpIKigleA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/ticker": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/loaders": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
-      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.1.0.tgz",
+      "integrity": "sha512-0RcJuWKJx+4r2lZoVWMfSdaMjC+gGTouDrnGFNX6NGRRXXE3vKQdyFlwwkaJzUefvsjbNe4cYxC7iws9lqL3oA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/math": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
-      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.1.0.tgz",
+      "integrity": "sha512-4INGyMqO7z02kTzHEp/7sl1TOrIhPmKLx3jNUDyQ/J7RPJJE3ZbgEktZcfmG0tofJoW3KbLqL4fd6k/FIi5Hsw==",
       "dev": true
     },
     "node_modules/@pixi/mesh": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
-      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.1.0.tgz",
+      "integrity": "sha512-l3zFMs9ENGB8y5PIRMCf2/7nHXu40yfeBZq4bPYIJJeHztkzaNKDbEFtDOx/Y1+QrG8VX4LiDWQ+sE7Tk+qIRA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/mesh-extras": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
-      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.1.0.tgz",
+      "integrity": "sha512-/l/ohKrxDRkho85TcGPZrturJPQRUSGLoctIkWCqhNePMk9ATLVQ2ihg7GR1glaYqvxMOQXj5qqIfEC/T7eMlw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/mesh": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/mixin-cache-as-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
-      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.1.0.tgz",
+      "integrity": "sha512-nwmXcfw7cFyhZwNDFHZLyE7dhJvLEZbm0BJ5cpiDb2HC1g4U5+BfGkjxQulUh2JfdOaqTp7EeU8K5okMVvcdnQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/canvas-renderer": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/mixin-get-child-by-name": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
-      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.1.0.tgz",
+      "integrity": "sha512-F78olhSbF9ukDigA27hqcPFYrqw0Yj6Z+2NLYVxyWD8vys8Cfev8wtztDk50WYVnCRk8BRYiTiEAtBGYIPSbYA==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.5.10"
+        "@pixi/display": "6.1.0"
       }
     },
     "node_modules/@pixi/mixin-get-global-position": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
-      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.1.0.tgz",
+      "integrity": "sha512-c/mrnEv7ZuKnjjaME+8jyOiP/Mtk2cq/UXDEM+lwOX98zVdxiaBFf13BhnMPnVq7Vq1+HeDDRZ2/VIlrLkU9Ag==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10"
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0"
       }
     },
     "node_modules/@pixi/particle-container": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
-      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.1.0.tgz",
+      "integrity": "sha512-Nu/UqG6n66b51UPdfQjuVfuGnM+D3caUqQCq2rLGVJIJmfrd38J0AooOaTtqePuadQWII2g3pFZ+dXv0oN1Blg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/polyfill": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
-      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.1.0.tgz",
+      "integrity": "sha512-gLz7eyfz5PAKxL7y9qI47O91WQyzuPFvuWm9sTxyncsgY7nchJxi6vUuxjLtFDd9vzl+/PXFDHyRGFyDe8tSkg==",
       "dev": true,
       "dependencies": {
         "object-assign": "^4.1.1",
@@ -1507,140 +1505,137 @@
       }
     },
     "node_modules/@pixi/prepare": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
-      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.1.0.tgz",
+      "integrity": "sha512-IdQ0gefbDt4anT59MxZznaY3EZQwvGE9K2Jo3+6t+3ZOvRlsgOLHdMFbNy9N0/MzKp9TAvuvzEj5WW2NoHx5Yw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/graphics": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/text": "6.1.0",
+        "@pixi/ticker": "6.1.0"
       }
     },
     "node_modules/@pixi/runner": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
-      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.1.0.tgz",
+      "integrity": "sha512-Pf6WmyBZSQg9mf3wpB3UvnZNX9GeRDoC4gMcQEYxw0rZDe0Z0JwzrkV0EGGyGHCZSssdx4+K1+vUxUIyFWdymw==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
-      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.1.0.tgz",
+      "integrity": "sha512-dVVOGqnCwZIHNtuAyzhw9QXZPtaxq8daDXYyRfmxfKS5SWX86HMl65KJW7rmA9TIua53i/igSSQVWgAhzRkUeg==",
       "dev": true,
-      "peerDependencies": {
-        "@pixi/constants": "6.5.10"
+      "dependencies": {
+        "ismobilejs": "^1.1.0"
       }
     },
     "node_modules/@pixi/sprite": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
-      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.1.0.tgz",
+      "integrity": "sha512-BnaRNiXgiqNNTN2a9WaeMPZtLP+v/D8W/fymNkjg2wWrs4FwnpT0lPGAL0YHFoBO328LI8qTCy6BCBZg74V4aQ==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/sprite-animated": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
-      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.1.0.tgz",
+      "integrity": "sha512-yL6Fe+xyXb9m/NkofUcigE3+NYUA3VrKajacf/ONXND897A7JLCihqXS9cHJHJGTNL3X+wsba1iZc9Rax5H0Sg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/ticker": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/ticker": "6.1.0"
       }
     },
     "node_modules/@pixi/sprite-tiling": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
-      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.1.0.tgz",
+      "integrity": "sha512-7a0NubCDrLG5pK7rrLAQJoju0EydL71kljm1TgqhcnoYV7n70Dbpoz+N4OuPyObOyEz9VvcnPMy5srp9FNllfw==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/spritesheet": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
-      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.1.0.tgz",
+      "integrity": "sha512-7kh7OuYujRGOAw1Pe6EtwH2Yzov80Qss2MtDlHNplJ+loImd/SCthFhsmpRrOb/lSBtxVn3h+pUzV0bc7bxQXg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/loaders": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/text": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
-      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.1.0.tgz",
+      "integrity": "sha512-Yul5LqVYr/XW21uNAoMrkjn7p63RfD19c0S6EWCV18QOJaOjz6ZwzPMg6wpm6b+2i/Ob6F8ZFZdSwAM0hznRYg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/core": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/text-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
-      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.1.0.tgz",
+      "integrity": "sha512-xcpRzXueq/XPqVJyd0FeJhdnmXcap8clZMrzLjND8blIWS9sJDJKXrpTmNco/JdOrU+vuOkWRau2OSJJKd882A==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/loaders": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/mesh": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/text": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
-      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.1.0.tgz",
+      "integrity": "sha512-tCh1dhmriLKLMcxTJ9usm1UZEK2+M5nEwvyec9kouF4EMi/PiGup65+pwTHK4SvjXD+9vbtTDam39fWYXCpRxg==",
       "dev": true,
       "peerDependencies": {
-        "@pixi/extensions": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/settings": "6.1.0"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
-      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-N7LaVjo2NiP0/4DMX6Hj6SsSoFFEA1Pc3U/I/kQJHj9OyLrNSpcl9PZEiPusnuhpMr+zlQKa+MMU+RyTj+06Hw==",
       "dev": true,
       "dependencies": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       },
       "peerDependencies": {
-        "@pixi/constants": "6.5.10",
-        "@pixi/settings": "6.5.10"
+        "@pixi/constants": "6.1.0",
+        "@pixi/settings": "6.1.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1771,12 +1766,6 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
-    },
-    "node_modules/@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -3524,6 +3513,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "dev": true
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -4624,47 +4619,46 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
-      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.1.0.tgz",
+      "integrity": "sha512-uBcM3wivcLq7CPwLGkcyGscsvRST4TcXSlgXaH46P6mxNnJoDgVJtEYwYP+5H9g7b96ZBo5We6lddO+mmz7cXw==",
       "dev": true,
       "dependencies": {
-        "@pixi/accessibility": "6.5.10",
-        "@pixi/app": "6.5.10",
-        "@pixi/compressed-textures": "6.5.10",
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/extract": "6.5.10",
-        "@pixi/filter-alpha": "6.5.10",
-        "@pixi/filter-blur": "6.5.10",
-        "@pixi/filter-color-matrix": "6.5.10",
-        "@pixi/filter-displacement": "6.5.10",
-        "@pixi/filter-fxaa": "6.5.10",
-        "@pixi/filter-noise": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/interaction": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/mesh-extras": "6.5.10",
-        "@pixi/mixin-cache-as-bitmap": "6.5.10",
-        "@pixi/mixin-get-child-by-name": "6.5.10",
-        "@pixi/mixin-get-global-position": "6.5.10",
-        "@pixi/particle-container": "6.5.10",
-        "@pixi/polyfill": "6.5.10",
-        "@pixi/prepare": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/sprite-animated": "6.5.10",
-        "@pixi/sprite-tiling": "6.5.10",
-        "@pixi/spritesheet": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/text-bitmap": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/accessibility": "6.1.0",
+        "@pixi/app": "6.1.0",
+        "@pixi/compressed-textures": "6.1.0",
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/extract": "6.1.0",
+        "@pixi/filter-alpha": "6.1.0",
+        "@pixi/filter-blur": "6.1.0",
+        "@pixi/filter-color-matrix": "6.1.0",
+        "@pixi/filter-displacement": "6.1.0",
+        "@pixi/filter-fxaa": "6.1.0",
+        "@pixi/filter-noise": "6.1.0",
+        "@pixi/graphics": "6.1.0",
+        "@pixi/interaction": "6.1.0",
+        "@pixi/loaders": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/mesh": "6.1.0",
+        "@pixi/mesh-extras": "6.1.0",
+        "@pixi/mixin-cache-as-bitmap": "6.1.0",
+        "@pixi/mixin-get-child-by-name": "6.1.0",
+        "@pixi/mixin-get-global-position": "6.1.0",
+        "@pixi/particle-container": "6.1.0",
+        "@pixi/polyfill": "6.1.0",
+        "@pixi/prepare": "6.1.0",
+        "@pixi/runner": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/sprite-animated": "6.1.0",
+        "@pixi/sprite-tiling": "6.1.0",
+        "@pixi/spritesheet": "6.1.0",
+        "@pixi/text": "6.1.0",
+        "@pixi/text-bitmap": "6.1.0",
+        "@pixi/ticker": "6.1.0",
+        "@pixi/utils": "6.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6502,176 +6496,176 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.5.10.tgz",
-      "integrity": "sha512-URrI1H+1kjjHSyhY1QXcUZ8S3omdVTrXg5y0gndtpOhIelErBTC9NWjJfw6s0Rlmv5+x5VAitQTgw9mRiatDgw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-6.1.0.tgz",
+      "integrity": "sha512-SDbu08F0eXTc5jqkJdLoX5G6yrSD68V5X7nU9+AfVL5mYdR+wkAuDXjcOINbGq2vxHPN6fgoBNZIDNPfRHeATw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/app": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.5.10.tgz",
-      "integrity": "sha512-VsNHLajZ5Dbc/Zrj7iWmIl3eu6Fec+afjW/NXXezD8Sp3nTDF0bv5F+GDgN/zSc2gqIvPHyundImT7hQGBDghg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-6.1.0.tgz",
+      "integrity": "sha512-QIMNyMpswWAIXo1RhTbnem7DEdNnrYCV8RLK9E9nZ3NlzP3587IuMEmNfwZp7PsvMJXehH2opY/hlYxVOmYxew==",
       "dev": true,
       "requires": {}
     },
+    "@pixi/canvas-renderer": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-6.1.0.tgz",
+      "integrity": "sha512-dukgaw9OQyFjTZZ/R2jvf+cyxVQA7P+wJVtGO4Ev/TlaLs85KKy1xtnRpgYbF/etPhORRgN232H6rys50B0YjQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
     "@pixi/compressed-textures": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.5.10.tgz",
-      "integrity": "sha512-41NT5mkfam47DrkB8xMp3HUZDt7139JMB6rVNOmb3u2vm+2mdy9tzi5s9nN7bG9xgXlchxcFzytTURk+jwXVJA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-6.1.0.tgz",
+      "integrity": "sha512-3Go+GT43avgzyX4+fFYiTEfjR5pHrzafKpVlMvttC9xGRhMV1BZFDi1rKjHYuYk8SgNycuqRa2RulsoVq0bQUw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/constants": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.5.10.tgz",
-      "integrity": "sha512-PUF2Y9YISRu5eVrVVHhHCWpc/KmxQTg3UH8rIUs8UI9dCK41/wsPd3pEahzf7H47v7x1HCohVZcFO3XQc1bUDw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.1.0.tgz",
+      "integrity": "sha512-4mIvvyiovu/tT1m32fQO/pYwGxO/ch9ZGOArAcsVKx0gWEk/Whi0fuJVxgCemu8gpSFkcIJreWnOiLUzZCVpdQ==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.5.10.tgz",
-      "integrity": "sha512-Gdzp5ENypyglvsh5Gv3teUZnZnmizo4xOsL+QqmWALdFlJXJwLJMVhKVThV/q/095XR6i4Ou54oshn+m4EkuFw==",
-      "dev": true,
-      "requires": {
-        "@types/offscreencanvas": "^2019.6.4"
-      }
-    },
-    "@pixi/display": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.5.10.tgz",
-      "integrity": "sha512-NxFdDDxlbH5fQkzGHraLGoTMucW9pVgXqQm13TSmkA3NWIi/SItHL4qT2SI8nmclT9Vid1VDEBCJFAbdeuQw1Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-u6pXk8K05ZLhFNQxg+mtlHA6IjV0+lr/IDrEbx55eDZo+ImJwI4ummkJ/uiXaNn04GG0tVAQt+y5+e3fJjVFEQ==",
       "dev": true,
       "requires": {}
     },
-    "@pixi/extensions": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-6.5.10.tgz",
-      "integrity": "sha512-EIUGza+E+sCy3dupuIjvRK/WyVyfSzHb5XsxRaxNrPwvG1iIUIqNqZ3owLYCo4h17fJWrj/yXVufNNtUKQccWQ==",
-      "dev": true
+    "@pixi/display": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.1.0.tgz",
+      "integrity": "sha512-Jb1V54kpJXiGjKFx1qe5NhZyl1u6Z1t3o6mWawIFbXKiOJs+nkouUqRyPX2877cu1zkufbAalEe5V8WXOkqixg==",
+      "dev": true,
+      "requires": {}
     },
     "@pixi/extract": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.5.10.tgz",
-      "integrity": "sha512-hXFIc4EGs14GFfXAjT1+6mzopzCMWeXeai38/Yod3vuBXkkp8+ksen6kE09vTnB9l1IpcIaCM+XZEokuqoGX2A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-6.1.0.tgz",
+      "integrity": "sha512-QqOb9jZ473mt8NDuAnfD/oUuXefspGLOoVTfHD+NVRP0J3P4Mnzq98ljHHpOFII/XgM8Jam6YRuOlTGyT7H+vg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-alpha": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.5.10.tgz",
-      "integrity": "sha512-GWHLJvY0QOIDRjVx0hdUff6nl/PePQg84i8XXPmANrvA+gJ/eSRTQRmQcdgInQfawENADB/oRqpcCct6IAcKpQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-6.1.0.tgz",
+      "integrity": "sha512-giNst0xR8h3Ulkk3u6JEN8L1TmZsE5JEPZ+brvdZ336k6wiRMxkqIZ2wt1w9cQLq3PY3MAiUO+SZkYr4Zr1GJg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-blur": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.5.10.tgz",
-      "integrity": "sha512-LJsRocVOdM9hTzZKjP+jmkfoL1nrJi5XpR0ItgRN8fflOC7A7Ln4iPe7nukbbq3H7QhZSunbygMubbO6xhThZw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-6.1.0.tgz",
+      "integrity": "sha512-EskO2DjKGyOwSMQIqVkONJgG8rdF7Ja9EtBBuWGL6V+lE7DUQ0I25+D13+12HD3OMUsEnXyZWmlYtGW9BD9P7g==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-color-matrix": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.5.10.tgz",
-      "integrity": "sha512-C2S44/EoWTrhqedLWOZTq9GZV5loEq1+MhyK9AUzEubWGMHhou1Juhn2mRZ7R6flKPCRQNKrXpStUwCAouud3Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-6.1.0.tgz",
+      "integrity": "sha512-8OE8EDyV8KEUhcqwQxeNvW6r0YMBrQXS7IZLUlCvIVdM5rI24qBA1n9ec5w8ofe7A6jdMArmV4NwiNiSHCkYvw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-displacement": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.5.10.tgz",
-      "integrity": "sha512-fbblMYyPX/hO3Tpoaa4tOBYxqp4TxjNrz6xyt15tKSVxWQElk+Tx98GJ+aaBoiHOKt8ezzHplStWoHG++JIv/w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-6.1.0.tgz",
+      "integrity": "sha512-ZmsLEYhLQLxVbhP688ofv0bmfRXObYk2Xa3ORwKgivyJeX3UqizP+OUHa1mJ+4n6Q50BwtCra/Cg+TJ0q2R0wQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-fxaa": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.5.10.tgz",
-      "integrity": "sha512-wbHL9UtY3g7jTyvO8JaZks6DqV8AO5c96Hfu0zfndWBPs79Ul6/sq3LD2eE+yq5vK5T2R9Sr4s54ls1JT3Sppg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-6.1.0.tgz",
+      "integrity": "sha512-htFHMvW7GId9UTw5c8Mdd4FU3RGTg9aSsQ04yQCJekm54pwQsTGzkbElGTVWHznurflOhjAJJRib6dtWW1CY8A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/filter-noise": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.5.10.tgz",
-      "integrity": "sha512-CX+/06NVaw3HsjipZVb7aemkca0TC8I6qfKI4lx2ugxS/6G6zkY5zqd8+nVSXW4DpUXB6eT0emwfRv6N00NvuA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-6.1.0.tgz",
+      "integrity": "sha512-5qdW1UZOcN8pJsyp/L7qNzGvigGwKB0c+RvI9LKWn/DsWC4WfAhatMtKV7dTsYNSRE+MWaFbelBQZT6wYw05Jg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/graphics": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.5.10.tgz",
-      "integrity": "sha512-KPHGJ910fi8bRQQ+VcTIgrK+bKIm8yAQaZKPqMtm14HzHPGcES6HkgeNY1sd7m8J4aS9btm5wOSyFu0p5IzTpA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.1.0.tgz",
+      "integrity": "sha512-NfbVX/TIXYrzUDItrXCg6c9LKM6Td1O+xXFnM9uP6EQQ1cyH5uUHtkSR0xgnPpdcs8IEa/FgyOmABEJ+G17syA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/interaction": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.5.10.tgz",
-      "integrity": "sha512-v809pJmXA2B9dV/vdrDMUqJT+fBB/ARZli2YRmI2dPbEbkaYr8FNmxCAJnwT8o+ymTx044Ie820hn9tVrtMtfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-6.1.0.tgz",
+      "integrity": "sha512-0GijG3v7oWET96FaFC59ozNrXa5D/fROpZSh2ywwL0NRvftLcjHOSDMGxDXhrlfpsjPgLVqDQQUHAcpIKigleA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/loaders": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.5.10.tgz",
-      "integrity": "sha512-AuK7mXBmyVsDFL9DDFPB8sqP8fwQ2NOktvu98bQuJl0/p/UeK/0OAQnF3wcf3FeBv5YGXfNHL21c2DCisjKfTg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-6.1.0.tgz",
+      "integrity": "sha512-0RcJuWKJx+4r2lZoVWMfSdaMjC+gGTouDrnGFNX6NGRRXXE3vKQdyFlwwkaJzUefvsjbNe4cYxC7iws9lqL3oA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/math": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.5.10.tgz",
-      "integrity": "sha512-fxeu7ykVbMGxGV2S3qRTupHToeo1hdWBm8ihyURn3BMqJZe2SkZEECPd5RyvIuuNUtjRnmhkZRnF3Jsz2S+L0g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.1.0.tgz",
+      "integrity": "sha512-4INGyMqO7z02kTzHEp/7sl1TOrIhPmKLx3jNUDyQ/J7RPJJE3ZbgEktZcfmG0tofJoW3KbLqL4fd6k/FIi5Hsw==",
       "dev": true
     },
     "@pixi/mesh": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.5.10.tgz",
-      "integrity": "sha512-tUNPsdp5/t/yRsCmfxIcufIfbQVzgAlMNgQ1igWOkSxzhB7vlEbZ8ZLLW5tQcNyM/r7Nhjz+RoB+RD+/BCtvlA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-6.1.0.tgz",
+      "integrity": "sha512-l3zFMs9ENGB8y5PIRMCf2/7nHXu40yfeBZq4bPYIJJeHztkzaNKDbEFtDOx/Y1+QrG8VX4LiDWQ+sE7Tk+qIRA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mesh-extras": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.5.10.tgz",
-      "integrity": "sha512-UCG7OOPPFeikrX09haCibCMR0jPQ4UJ+4HiYiAv/3dahq5eEzBx+yAwVtxcVCjonkTf/lu5SzmHdzpsbHLx5aw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-6.1.0.tgz",
+      "integrity": "sha512-/l/ohKrxDRkho85TcGPZrturJPQRUSGLoctIkWCqhNePMk9ATLVQ2ihg7GR1glaYqvxMOQXj5qqIfEC/T7eMlw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.5.10.tgz",
-      "integrity": "sha512-HV4qPZt8R7uuPZf1XE5S0e3jbN4+/EqgAIkueIyK3Em+0IO1rCmIbzzYxFPxkElMUu5VvN1r4hXK846z9ITnhw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-6.1.0.tgz",
+      "integrity": "sha512-nwmXcfw7cFyhZwNDFHZLyE7dhJvLEZbm0BJ5cpiDb2HC1g4U5+BfGkjxQulUh2JfdOaqTp7EeU8K5okMVvcdnQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.5.10.tgz",
-      "integrity": "sha512-YYd9wjnI/4aKY0H5Ij413UppVZn3YE1No2CZrNevV6WbhylsJucowY3hJihtl9mxkpwtaUIyWMjmphkbOinbzA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-6.1.0.tgz",
+      "integrity": "sha512-F78olhSbF9ukDigA27hqcPFYrqw0Yj6Z+2NLYVxyWD8vys8Cfev8wtztDk50WYVnCRk8BRYiTiEAtBGYIPSbYA==",
       "dev": true,
       "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.5.10.tgz",
-      "integrity": "sha512-A83gTZP9CdQAyrAvOZl1P707Q0QvIC0V8UnBAMd4GxuhMOXJtXVPCdmfPVXUrfoywgnH+/Bgimq5xhsXTf8Hzg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-6.1.0.tgz",
+      "integrity": "sha512-c/mrnEv7ZuKnjjaME+8jyOiP/Mtk2cq/UXDEM+lwOX98zVdxiaBFf13BhnMPnVq7Vq1+HeDDRZ2/VIlrLkU9Ag==",
       "dev": true,
       "requires": {}
     },
     "@pixi/particle-container": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.5.10.tgz",
-      "integrity": "sha512-CCNAdYGzKoOc3FtK2kyWCNjygdHppeOEqqK189yhg3yRSsvby+HMms/cM6bLK/4Vf6mFoAy1na3w/oXpqTR2Ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-6.1.0.tgz",
+      "integrity": "sha512-Nu/UqG6n66b51UPdfQjuVfuGnM+D3caUqQCq2rLGVJIJmfrd38J0AooOaTtqePuadQWII2g3pFZ+dXv0oN1Blg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/polyfill": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.5.10.tgz",
-      "integrity": "sha512-KDTWyr285VvPM8GGTVIZAhmxGrOlTznUGK/9kWS3GtrogwLWn41S/86Yej1gYvotVyUomCcOok33Jzahb+vX1w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-6.1.0.tgz",
+      "integrity": "sha512-gLz7eyfz5PAKxL7y9qI47O91WQyzuPFvuWm9sTxyncsgY7nchJxi6vUuxjLtFDd9vzl+/PXFDHyRGFyDe8tSkg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
@@ -6679,82 +6673,84 @@
       }
     },
     "@pixi/prepare": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.5.10.tgz",
-      "integrity": "sha512-PHMApz/GPg7IX/7+2S98criN2+Mp+fgiKpojV9cnl0SlW2zMxfAHBBi8zik9rHBgjx8X6d6bR0MG1rPtb6vSxQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-6.1.0.tgz",
+      "integrity": "sha512-IdQ0gefbDt4anT59MxZznaY3EZQwvGE9K2Jo3+6t+3ZOvRlsgOLHdMFbNy9N0/MzKp9TAvuvzEj5WW2NoHx5Yw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/runner": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.5.10.tgz",
-      "integrity": "sha512-4HiHp6diCmigJT/DSbnqQP62OfWKmZB7zPWMdV1AEdr4YT1QxzXAW1wHg7dkoEfyTHqZKl0tm/zcqKq/iH7tMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.1.0.tgz",
+      "integrity": "sha512-Pf6WmyBZSQg9mf3wpB3UvnZNX9GeRDoC4gMcQEYxw0rZDe0Z0JwzrkV0EGGyGHCZSssdx4+K1+vUxUIyFWdymw==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.5.10.tgz",
-      "integrity": "sha512-ypAS5L7pQ2Qb88yQK72bXtc7sD8OrtLWNXdZ/gnw5kwSWCFaOSoqhKqJCXrR5DQtN98+RQefwbEAmMvqobhFyw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.1.0.tgz",
+      "integrity": "sha512-dVVOGqnCwZIHNtuAyzhw9QXZPtaxq8daDXYyRfmxfKS5SWX86HMl65KJW7rmA9TIua53i/igSSQVWgAhzRkUeg==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ismobilejs": "^1.1.0"
+      }
     },
     "@pixi/sprite": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.5.10.tgz",
-      "integrity": "sha512-UiK+8LgM9XQ/SBDKjRgZ8WggdOSlFRXqiWjEZVmNkiyU8HvXeFzWPRhpc8RR1zDwAUhZWKtMhF8X/ba9m+z2lg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.1.0.tgz",
+      "integrity": "sha512-BnaRNiXgiqNNTN2a9WaeMPZtLP+v/D8W/fymNkjg2wWrs4FwnpT0lPGAL0YHFoBO328LI8qTCy6BCBZg74V4aQ==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-animated": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.5.10.tgz",
-      "integrity": "sha512-x1kayucAqpVbNk+j+diC/7sQGQsAl6NCH1J2/EEaiQjlV3GOx1MXS9Tft1N1Y1y7otbg1XsnBd60/Yzcp05pxA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-6.1.0.tgz",
+      "integrity": "sha512-yL6Fe+xyXb9m/NkofUcigE3+NYUA3VrKajacf/ONXND897A7JLCihqXS9cHJHJGTNL3X+wsba1iZc9Rax5H0Sg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/sprite-tiling": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.5.10.tgz",
-      "integrity": "sha512-lDFcPuwExrdJhli+WmjPivChjeCG6NiRl36iQ8n2zVi/MYVv9qfKCA6IdU7HBWk1AZdsg6KUTpwfmVLUI+qz3w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-6.1.0.tgz",
+      "integrity": "sha512-7a0NubCDrLG5pK7rrLAQJoju0EydL71kljm1TgqhcnoYV7n70Dbpoz+N4OuPyObOyEz9VvcnPMy5srp9FNllfw==",
       "dev": true,
       "requires": {}
     },
     "@pixi/spritesheet": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.5.10.tgz",
-      "integrity": "sha512-7uOZ1cYyYtPb0ZEgXV1SZ8ujtluZNY0TL5z3+Qc8cgGGZK/MaWG7N6Wf+uR4BR2x8FLNwcyN5IjbQDKCpblrmg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-6.1.0.tgz",
+      "integrity": "sha512-7kh7OuYujRGOAw1Pe6EtwH2Yzov80Qss2MtDlHNplJ+loImd/SCthFhsmpRrOb/lSBtxVn3h+pUzV0bc7bxQXg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.5.10.tgz",
-      "integrity": "sha512-ikwkonLJ+6QmEVW8Ji9fS5CjrKNbU4mHzYuwRQas/VJQuSWgd0myCcaw6ZbF1oSfQe70HgbNOR0sH8Q3Com0qg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-6.1.0.tgz",
+      "integrity": "sha512-Yul5LqVYr/XW21uNAoMrkjn7p63RfD19c0S6EWCV18QOJaOjz6ZwzPMg6wpm6b+2i/Ob6F8ZFZdSwAM0hznRYg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/text-bitmap": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.5.10.tgz",
-      "integrity": "sha512-g/iFIMGp6Pfi0BvX6Ykp48Z6JXVgKOrc7UCIR9CM21wYcCiQGqtdFwstV236xk6/D8NToUtSOcifhtQ28dVTdQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-6.1.0.tgz",
+      "integrity": "sha512-xcpRzXueq/XPqVJyd0FeJhdnmXcap8clZMrzLjND8blIWS9sJDJKXrpTmNco/JdOrU+vuOkWRau2OSJJKd882A==",
       "dev": true,
       "requires": {}
     },
     "@pixi/ticker": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.5.10.tgz",
-      "integrity": "sha512-UqX1XYtzqFSirmTOy8QAK4Ccg4KkIZztrBdRPKwFSOEiKAJoGDCSBmyQBo/9aYQKGObbNnrJ7Hxv3/ucg3/1GA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.1.0.tgz",
+      "integrity": "sha512-tCh1dhmriLKLMcxTJ9usm1UZEK2+M5nEwvyec9kouF4EMi/PiGup65+pwTHK4SvjXD+9vbtTDam39fWYXCpRxg==",
       "dev": true,
       "requires": {}
     },
     "@pixi/utils": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.5.10.tgz",
-      "integrity": "sha512-4f4qDMmAz9IoSAe08G2LAxUcEtG9jSdudfsMQT2MG+OpfToirboE6cNoO0KnLCvLzDVE/mfisiQ9uJbVA9Ssdw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-N7LaVjo2NiP0/4DMX6Hj6SsSoFFEA1Pc3U/I/kQJHj9OyLrNSpcl9PZEiPusnuhpMr+zlQKa+MMU+RyTj+06Hw==",
       "dev": true,
       "requires": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.4",
+        "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -6887,12 +6883,6 @@
       "requires": {
         "undici-types": "~5.26.4"
       }
-    },
-    "@types/offscreencanvas": {
-      "version": "2019.7.3",
-      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
-      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
-      "dev": true
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -8128,6 +8118,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "dev": true
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -8967,47 +8963,46 @@
       "dev": true
     },
     "pixi.js": {
-      "version": "6.5.10",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.5.10.tgz",
-      "integrity": "sha512-Z2mjeoISml2iuVwT1e/BQwERYM2yKoiR08ZdGrg8y5JjeuVptfTrve4DbPMRN/kEDodesgQZGV/pFv0fE9Q2SA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-6.1.0.tgz",
+      "integrity": "sha512-uBcM3wivcLq7CPwLGkcyGscsvRST4TcXSlgXaH46P6mxNnJoDgVJtEYwYP+5H9g7b96ZBo5We6lddO+mmz7cXw==",
       "dev": true,
       "requires": {
-        "@pixi/accessibility": "6.5.10",
-        "@pixi/app": "6.5.10",
-        "@pixi/compressed-textures": "6.5.10",
-        "@pixi/constants": "6.5.10",
-        "@pixi/core": "6.5.10",
-        "@pixi/display": "6.5.10",
-        "@pixi/extensions": "6.5.10",
-        "@pixi/extract": "6.5.10",
-        "@pixi/filter-alpha": "6.5.10",
-        "@pixi/filter-blur": "6.5.10",
-        "@pixi/filter-color-matrix": "6.5.10",
-        "@pixi/filter-displacement": "6.5.10",
-        "@pixi/filter-fxaa": "6.5.10",
-        "@pixi/filter-noise": "6.5.10",
-        "@pixi/graphics": "6.5.10",
-        "@pixi/interaction": "6.5.10",
-        "@pixi/loaders": "6.5.10",
-        "@pixi/math": "6.5.10",
-        "@pixi/mesh": "6.5.10",
-        "@pixi/mesh-extras": "6.5.10",
-        "@pixi/mixin-cache-as-bitmap": "6.5.10",
-        "@pixi/mixin-get-child-by-name": "6.5.10",
-        "@pixi/mixin-get-global-position": "6.5.10",
-        "@pixi/particle-container": "6.5.10",
-        "@pixi/polyfill": "6.5.10",
-        "@pixi/prepare": "6.5.10",
-        "@pixi/runner": "6.5.10",
-        "@pixi/settings": "6.5.10",
-        "@pixi/sprite": "6.5.10",
-        "@pixi/sprite-animated": "6.5.10",
-        "@pixi/sprite-tiling": "6.5.10",
-        "@pixi/spritesheet": "6.5.10",
-        "@pixi/text": "6.5.10",
-        "@pixi/text-bitmap": "6.5.10",
-        "@pixi/ticker": "6.5.10",
-        "@pixi/utils": "6.5.10"
+        "@pixi/accessibility": "6.1.0",
+        "@pixi/app": "6.1.0",
+        "@pixi/compressed-textures": "6.1.0",
+        "@pixi/constants": "6.1.0",
+        "@pixi/core": "6.1.0",
+        "@pixi/display": "6.1.0",
+        "@pixi/extract": "6.1.0",
+        "@pixi/filter-alpha": "6.1.0",
+        "@pixi/filter-blur": "6.1.0",
+        "@pixi/filter-color-matrix": "6.1.0",
+        "@pixi/filter-displacement": "6.1.0",
+        "@pixi/filter-fxaa": "6.1.0",
+        "@pixi/filter-noise": "6.1.0",
+        "@pixi/graphics": "6.1.0",
+        "@pixi/interaction": "6.1.0",
+        "@pixi/loaders": "6.1.0",
+        "@pixi/math": "6.1.0",
+        "@pixi/mesh": "6.1.0",
+        "@pixi/mesh-extras": "6.1.0",
+        "@pixi/mixin-cache-as-bitmap": "6.1.0",
+        "@pixi/mixin-get-child-by-name": "6.1.0",
+        "@pixi/mixin-get-global-position": "6.1.0",
+        "@pixi/particle-container": "6.1.0",
+        "@pixi/polyfill": "6.1.0",
+        "@pixi/prepare": "6.1.0",
+        "@pixi/runner": "6.1.0",
+        "@pixi/settings": "6.1.0",
+        "@pixi/sprite": "6.1.0",
+        "@pixi/sprite-animated": "6.1.0",
+        "@pixi/sprite-tiling": "6.1.0",
+        "@pixi/spritesheet": "6.1.0",
+        "@pixi/text": "6.1.0",
+        "@pixi/text-bitmap": "6.1.0",
+        "@pixi/ticker": "6.1.0",
+        "@pixi/utils": "6.1.0"
       }
     },
     "pkg-dir": {

--- a/package.json
+++ b/package.json
@@ -42,14 +42,14 @@
     "pixi.js": "^6.1.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "pixi.js": "^6.1.0",
-    "typescript": "^4.2.3",
     "@types/jest": "^29.2.6",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.5",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
     "eslint": "^8.57.0",
-    "eslint-plugin-disable-autofix": "^4.2.0"
+    "eslint-plugin-disable-autofix": "^4.2.0",
+    "jest": "^29.3.1",
+    "pixi.js": "^6.1.0",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixijs-actions",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Reece Como <reece.como@gmail.com>",
   "authors": [
     "Reece Como <reece.como@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tweening"
   ],
   "peerDependencies": {
-    "pixi.js": "^6.1.0 || ^7.0.0 || ^8.0.0"
+    "pixi.js": "^6.3.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",
@@ -48,7 +48,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-disable-autofix": "^4.2.0",
     "jest": "^29.3.1",
-    "pixi.js": "^6.1.0",
+    "pixi.js": "^6.3.0",
     "ts-jest": "^29.0.5",
     "typescript": "^4.2.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tweening"
   ],
   "peerDependencies": {
-    "pixi.js": ">=6.1.0"
+    "pixi.js": "^6.1.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "pixi.js": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-disable-autofix": "^4.2.0",
     "jest": "^29.3.1",
-    "pixi.js": "^6.3.0",
+    "pixi.js": "6.3.x",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.2.3"
+    "typescript": "4.9.5"
   }
 }

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -17,7 +17,7 @@ import {
   RotateByAction,
   RotateToAction,
   RunBlockAction,
-  RunOnChildWithNameAction,
+  RunOnChildAction,
   ScaleByAction,
   ScaleToAction,
   ScaleToSizeAction,
@@ -33,7 +33,7 @@ const DEG_TO_RAD = Math.PI / 180;
 /**
  * Create, configure, and run actions in PixiJS.
  *
- * An action is an animation that is executed by a DisplayObject in the canvas.
+ * An action is an animation that is executed by a target node.
  *
  * ### Setup:
  * Bind `Action.tick(deltaTimeMs)` to your renderer/shared ticker to activate actions.
@@ -491,7 +491,7 @@ export abstract class _ extends Action {
   }
 
   //
-  // ----------------- Display Object Actions: -----------------
+  // ----------------- Container Actions: -----------------
   //
 
   /**
@@ -543,8 +543,8 @@ export abstract class _ extends Action {
    * This action is reversible; it tells the child to execute the reverse of the action specified by
    * the action parameter.
    */
-  public static runOnChildWithName(action: Action, name: string): Action {
-    return new RunOnChildWithNameAction(action, name);
+  public static runOnChild(nameOrLabel: string, action: Action): Action {
+    return new RunOnChildAction(action, nameOrLabel);
   }
 
   //

--- a/src/Container.mixin.ts
+++ b/src/Container.mixin.ts
@@ -1,17 +1,13 @@
 import { _ as Action } from "./Action";
 import { ActionTicker } from "./lib/ActionTicker";
 
-//
-// ----- DisplayObject Mixin: -----
-//
-
 /**
- * Register the mixins for PIXI.DisplayObject.
+ * Register the mixin for PIXI.Container.
  *
- * @param displayObject A reference to `PIXI.DisplayObject`.
+ * @param container A reference to `PIXI.Container`.
  */
-export function registerDisplayObjectMixin(displayObject: any): void {
-  const prototype = displayObject.prototype;
+export function registerPixiJSActionsMixin(container: any): void {
+  const prototype = container.prototype;
 
   // - Properties:
   prototype.speed = 1.0;

--- a/src/__tests__/Action.test.ts
+++ b/src/__tests__/Action.test.ts
@@ -548,11 +548,11 @@ describe('Action', () => {
 
   describe('runOnChild()', () => {
     it('passes the action to the named child with PixiJS v8 label', () => {
-      const childNode = new Container();
-      (childNode as any).label = 'myChildNode';
+      const childNode: any = new Container();
+      childNode.label = 'myChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode);
+      parentNode.addChild(childNode as any);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -574,7 +574,7 @@ describe('Action', () => {
       childNode.name = 'myChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode);
+      parentNode.addChild(childNode as any);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -596,7 +596,7 @@ describe('Action', () => {
       childNode.name = 'otherChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode);
+      parentNode.addChild(childNode as any);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -742,8 +742,8 @@ describe('Action and nodes', () => {
       const grandparent = new Container();
       const parent = new Container();
       const node = new Container();
-      grandparent.addChild(parent);
-      parent.addChild(node);
+      grandparent.addChild(parent as any);
+      parent.addChild(node as any);
 
       grandparent.speed = 4.0;
       parent.speed = 0.5;
@@ -805,8 +805,8 @@ describe('Action and nodes', () => {
       const grandparent = new Container();
       const parent = new Container();
       const node = new Container();
-      grandparent.addChild(parent);
-      parent.addChild(node);
+      grandparent.addChild(parent as any);
+      parent.addChild(node as any);
 
       node.run(action);
       expect(node.hasActions()).toBe(true);

--- a/src/__tests__/Action.test.ts
+++ b/src/__tests__/Action.test.ts
@@ -548,11 +548,11 @@ describe('Action', () => {
 
   describe('runOnChild()', () => {
     it('passes the action to the named child with PixiJS v8 label', () => {
-      const childNode: any = new Container();
-      childNode.label = 'myChildNode';
+      const childNode = new Container();
+      (childNode as any).label = 'myChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode as any);
+      parentNode.addChild(childNode);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -574,7 +574,7 @@ describe('Action', () => {
       childNode.name = 'myChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode as any);
+      parentNode.addChild(childNode);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -596,7 +596,7 @@ describe('Action', () => {
       childNode.name = 'otherChildNode';
 
       const parentNode = new Container();
-      parentNode.addChild(childNode as any);
+      parentNode.addChild(childNode);
 
       parentNode.run(
         Action.runOnChild('myChildNode', Action.rotateBy(Math.PI, 1.0))
@@ -742,8 +742,8 @@ describe('Action and nodes', () => {
       const grandparent = new Container();
       const parent = new Container();
       const node = new Container();
-      grandparent.addChild(parent as any);
-      parent.addChild(node as any);
+      grandparent.addChild(parent);
+      parent.addChild(node);
 
       grandparent.speed = 4.0;
       parent.speed = 0.5;
@@ -805,8 +805,8 @@ describe('Action and nodes', () => {
       const grandparent = new Container();
       const parent = new Container();
       const node = new Container();
-      grandparent.addChild(parent as any);
-      parent.addChild(node as any);
+      grandparent.addChild(parent);
+      parent.addChild(node);
 
       node.run(action);
       expect(node.hasActions()).toBe(true);

--- a/src/actions/display-object/RunOnChildAction.ts
+++ b/src/actions/display-object/RunOnChildAction.ts
@@ -19,8 +19,15 @@ export class RunOnChildAction extends Action {
       throw new TypeError('The target did not have children.');
     }
 
-    const child: any = target.children
-      .find((child: any) => child.name === this.nameOrLabel || child.label === this.nameOrLabel);
+    let child: any;
+
+    if ('getChildByLabel' in target as any) {
+      child = (target as any).getChildByLabel(this.nameOrLabel); // PixiJS v8
+    }
+    else {
+      child = target.children
+        .find((child: any) => child.label === this.nameOrLabel || child.name === this.nameOrLabel);
+    }
 
     if (child) {
       child.run(this.action);

--- a/src/actions/display-object/RunOnChildWithNameAction.ts
+++ b/src/actions/display-object/RunOnChildWithNameAction.ts
@@ -1,25 +1,32 @@
 import { Action } from '../../lib/Action';
 
-export class RunOnChildWithNameAction extends Action {
+export class RunOnChildAction extends Action {
   public constructor(
     protected readonly action: Action,
-    protected readonly name: string,
+    protected readonly nameOrLabel: string,
   ) {
     super(0);
   }
 
   public reversed(): Action {
-    return new RunOnChildWithNameAction(this.action.reversed(), this.name)
+    return new RunOnChildAction(this.action.reversed(), this.nameOrLabel)
       .setTimingMode(this.timingMode)
       .setSpeed(this.speed);
   }
 
   protected onTick(target: TargetNode): void {
-    if (!('children' in target) || !Array.isArray(target.children)) {
+    if (target.children === undefined || !Array.isArray(target.children)) {
+      throw new TypeError('The target did not have children.');
+    }
+
+    const child: any = target.children
+      .find((child: any) => child.name === this.nameOrLabel || child.label === this.nameOrLabel);
+
+    if (child) {
+      child.run(this.action);
       return;
     }
 
-    const child: TargetNode | undefined = target.children.find((c: any) => c.name === this.name);
-    child?.run(this.action);
+    throw new ReferenceError(`The target did not have a child matching '${this.nameOrLabel}'.`);
   }
 }

--- a/src/actions/display-object/index.ts
+++ b/src/actions/display-object/index.ts
@@ -1,3 +1,3 @@
 export * from './RemoveFromParentAction';
-export * from './RunOnChildWithNameAction';
+export * from './RunOnChildAction';
 export * from './SetVisibleAction';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { _ as Action } from "./Action";
 import { TimingMode, TimingModeFn } from "./TimingMode";
-import { registerDisplayObjectMixin } from './DisplayObject.mixin';
+import { registerPixiJSActionsMixin } from './Container.mixin';
 
 //
 // ----- PixiJS Actions library: -----
@@ -8,18 +8,18 @@ import { registerDisplayObjectMixin } from './DisplayObject.mixin';
 
 export {
   Action,
-  registerDisplayObjectMixin,
+  registerPixiJSActionsMixin,
   TimingMode,
   TimingModeFn,
 };
 
 //
-// ----- Types and documentation for the DisplayObject mixin: -----
+// ----- Types and documentation for the Container mixin: -----
 //
 
 declare module 'pixi.js' {
 
-  export interface DisplayObject {
+  export interface Container {
 
     /**
      * A boolean value that determines whether actions on the node and its descendants are processed.

--- a/src/lib/Action.ts
+++ b/src/lib/Action.ts
@@ -133,7 +133,7 @@ export abstract class Action {
   /**
    * Update function for the action.
    *
-   * @param target The affected display object.
+   * @param target The affected node.
    * @param t The elapsed progress of the action, with the timing mode function applied. Generally a scalar number between 0.0 and 1.0.
    * @param dt Relative change in progress since the previous animation change. Use this for relative actions.
    * @param ticker The action ticker running this update.

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@ declare global {
   type TimeInterval = number;
 
   /** Targeted display node. */
-  type TargetNode = PIXI.DisplayObject;
+  type TargetNode = PIXI.Container;
 
   /** Targeted display node with a width and height. */
   type SizedTargetNode = TargetNode & SizeLike;


### PR DESCRIPTION
Improves PixiV8 support by updating library type-hinting (and naming conventions) to `Container` from `DisplayObject`.

### What's changed?
- improves PixiV8 support by updating types to reflect common between v6, v7 and v8
- Replace references to `PIXI.DisplayObject` in types with `PIXI.Container`
- renamed `Action.runOnChildWithName(action, name)` to `Action.runOnChild(nameOrLabel, action)`
  - flipped argument order to be more expressive (sorry `SKAction.runOnChild(_: withName:)` 💔)
  - added under-the-hood support for v8's `getChildByLabel()` when available to minimize deprecation warnings and rename
  - changed error reporting behavior to report a `TypeError` when target can'wt have children, or `ReferenceError` when no child was found
  - no functional changes
- Added PIXI 6.1, 7.2 and 8.1 to test matrix to validate changes
